### PR TITLE
Dark redesign + anti-bot/RE positioning, job-search tooling, SEO, real CV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ static/image/*
 .DS_Store
 venv/
 .venv/
+
+# logs
+*.log

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, Request, HTTPException, Form
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, StreamingResponse, PlainTextResponse, Response
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -287,6 +287,8 @@ async def read_linkedin_jobs(
     continent: Optional[str] = None,
     date: Optional[str] = None,
     source: Optional[str] = None,  # Added source parameter
+    q: Optional[str] = None,  # Free-text keyword (title + company)
+    it_only: Optional[str] = None,  # Keep only IT-relevant jobs (relevant flag)
     page: int = 1,
     per_page: int = 20,
 ):
@@ -294,6 +296,16 @@ async def read_linkedin_jobs(
     per_page = max(min(per_page, 100), 1)
 
     query = {}
+    it_only_on = str(it_only).lower() in ("1", "true", "on", "yes")
+    if it_only_on:
+        query["relevant"] = True
+    keyword = (q or "").strip()
+    if keyword:
+        safe = re.escape(keyword)
+        query["$or"] = [
+            {"title": {"$regex": safe, "$options": "i"}},
+            {"company": {"$regex": safe, "$options": "i"}},
+        ]
     if country and country != "all":
         query["country"] = country
     if continent and continent != "all":
@@ -350,6 +362,8 @@ async def read_linkedin_jobs(
             "selected_continent": continent or "all",
             "selected_date": date or "all",
             "selected_source": source or "all",  # Pass selected source
+            "selected_q": keyword,  # Pass keyword back to the search box
+            "selected_it_only": it_only_on,  # Pass IT-only toggle state
             "total_jobs": total_jobs,
             "filtered_jobs_count": total_jobs,
             "page": page,
@@ -517,10 +531,168 @@ async def read_freework_job_detail(request: Request, job_id: str, return_page: i
     )
 
 
+# ---------------------------------------------------------------------------
+# Projects (single source of truth for the listing + case-study detail pages)
+# ---------------------------------------------------------------------------
+PROJECTS = [
+    {
+        "slug": "linkedin-job-scraper",
+        "title": "LinkedIn Job Scraper",
+        "desc": "Extracts tech jobs with filters by source, country, and date, then serves them through a searchable interface.",
+        "tech": ["Python", "Requests", "BeautifulSoup", "MongoDB", "GitHub Actions"],
+        "icon": "fab fa-linkedin-in",
+        "color": "cyan",
+        "url": "/jobs/linkedin",
+        "repo": "https://github.com/housine35/linkedin-job-scraper",
+        "date": "2025-06-15",
+        "tagline": "A self-hosted job radar that refreshes itself every 30 minutes.",
+        "problem": "LinkedIn has no public jobs API and aggressively rate-limits guests. I wanted a continuously updated, queryable database of tech roles without a paid data provider.",
+        "approach": [
+            "Reverse-engineered LinkedIn's guest `seeMoreJobPostings` endpoint and replicated its query parameters (time filter, work type, pagination).",
+            "Built a resilient fetch layer: rotating proxy with local-IP fallback, retries with backoff, and CAPTCHA/empty-response detection.",
+            "Normalized postings (URL-based dedup as `_id`) and enriched each with country/continent + an IT-relevance tag.",
+            "Scheduled the whole pipeline on GitHub Actions (cron every 30 min) writing into MongoDB Atlas.",
+        ],
+        "results": [
+            "70k+ postings indexed and kept fresh automatically",
+            "Country/continent enrichment with a memoized geocoder",
+            "Zero-cost hosting: GitHub Actions + Atlas free tier",
+        ],
+    },
+    {
+        "slug": "freework-scraper",
+        "title": "Freework Freelance Scraper",
+        "desc": "Collects freelance opportunities, remote modes, and daily rates for real-time job exploration.",
+        "tech": ["Scrapy", "FastAPI", "ETL", "MongoDB"],
+        "icon": "fas fa-briefcase",
+        "color": "emerald",
+        "url": "/jobs/freework",
+        "repo": "https://github.com/housine35/freework-job-scraper",
+        "date": "2025-07-01",
+        "tagline": "Freelance market intelligence with daily CSV snapshots.",
+        "problem": "Freelance platforms surface daily rates and remote modes that are hard to track over time for rate benchmarking.",
+        "approach": [
+            "Crawled listings with Scrapy, normalizing city/department and remote mode.",
+            "Exposed the data through a FastAPI UI with filters and a daily CSV export gated by email.",
+            "Added a migration to backfill normalized location fields on historical data.",
+        ],
+        "results": [
+            "Filterable explorer by remote mode, location, and date",
+            "One-click daily CSV snapshot for offline analysis",
+        ],
+    },
+    {
+        "slug": "facebook-extractor",
+        "title": "Facebook Data Extractor",
+        "desc": "Captures post details and comments using authenticated browser automation and reverse-engineered internal endpoints.",
+        "tech": ["Playwright", "Reverse Engineering", "API Analysis"],
+        "icon": "fab fa-facebook-f",
+        "color": "blue",
+        "url": "https://facebook-scraper-q8aa.onrender.com/",
+        "repo": None,
+        "date": "2025-01-10",
+        "tagline": "Turning a hostile, JS-heavy UI into structured post + comment data.",
+        "problem": "Facebook renders content through obfuscated, frequently-changing internal GraphQL calls behind authentication and anti-automation defenses.",
+        "approach": [
+            "Analyzed network traffic with Proxyman/Charles to map the internal endpoints and required tokens.",
+            "Drove authenticated sessions with Playwright, replaying signed requests for stable extraction.",
+            "Wrote change-tolerant parsers that degrade gracefully when the markup shifts.",
+        ],
+        "results": [
+            "Structured posts + comments from a JS-only UI",
+            "Resilient to layout changes via fallback parsers",
+        ],
+    },
+    {
+        "slug": "tiktok-engine",
+        "title": "TikTok Extraction Engine",
+        "desc": "Retrieves post metadata and user graph data with anti-rate-limit handling and reverse-engineered request signatures.",
+        "tech": ["Automation", "Signature Reversing", "Data Pipelines"],
+        "icon": "fab fa-tiktok",
+        "color": "amber",
+        "url": "https://tiktok-scraper-yt8p.onrender.com/",
+        "repo": None,
+        "date": "2025-04-22",
+        "tagline": "Defeating request signing to read the public graph at scale.",
+        "problem": "TikTok signs its API requests (device/signature params) and rate-limits aggressively, blocking naive scrapers.",
+        "approach": [
+            "Reverse-engineered the request-signing scheme to forge valid signatures.",
+            "Implemented rotation and pacing to stay under rate limits.",
+            "Built pipelines to collect post metadata and user-graph relationships.",
+        ],
+        "results": [
+            "Stable access to post metadata + user graph",
+            "Custom request-signature generation",
+        ],
+    },
+    {
+        "slug": "assembly-senate-data",
+        "title": "French Assembly & Senate Data",
+        "desc": "Scrapes legislative records including bills, votes, and profiles from parliamentary sources.",
+        "tech": ["Public Data", "Parsing", "Normalization"],
+        "icon": "fas fa-landmark",
+        "color": "violet",
+        "url": None,
+        "repo": None,
+        "date": "2024-03-12",
+        "tagline": "Structured open-government data from messy official sources.",
+        "problem": "Parliamentary records are spread across inconsistent pages and formats, making analysis painful.",
+        "approach": [
+            "Parsed bills, votes, and member profiles from official parliamentary sources.",
+            "Normalized entities and relationships into a consistent schema.",
+        ],
+        "results": [
+            "Unified dataset of bills, votes, and profiles",
+        ],
+    },
+    {
+        "slug": "live-subtitle-capture",
+        "title": "Live Subtitle Capture",
+        "desc": "Captures live subtitles from video streams with OCR and near real-time text processing.",
+        "tech": ["OCR", "Streaming", "Puppeteer"],
+        "icon": "fas fa-video",
+        "color": "rose",
+        "url": "https://github.com/housine35/Aws_Puppeteer",
+        "repo": "https://github.com/housine35/Aws_Puppeteer",
+        "date": "2025-02-18",
+        "tagline": "Real-time subtitle extraction from live video.",
+        "problem": "Subtitles burned into or streamed over live video aren't available as text for downstream processing.",
+        "approach": [
+            "Captured frames from live streams with headless Puppeteer.",
+            "Applied OCR and near real-time text processing to recover subtitle text.",
+        ],
+        "results": [
+            "Near real-time subtitle text from live streams",
+        ],
+    },
+]
+PROJECTS_BY_SLUG = {p["slug"]: p for p in PROJECTS}
+
+# Cache for the homepage live job counter
+_job_stats_cache = {"expires_at": 0.0, "data": None}
+JOB_STATS_CACHE_TTL_SECONDS = int(os.getenv("JOB_STATS_CACHE_TTL_SECONDS", "300"))
+
+
+async def get_job_stats():
+    now = time.monotonic()
+    if _job_stats_cache["data"] and now < _job_stats_cache["expires_at"]:
+        return _job_stats_cache["data"]
+    stats = {"total": None, "relevant": None}
+    try:
+        stats["total"] = await linkedin_collection.estimated_document_count()
+    except Exception as e:
+        logger.warning(f"Could not fetch job stats: {e}")
+    _job_stats_cache["data"] = stats
+    _job_stats_cache["expires_at"] = now + JOB_STATS_CACHE_TTL_SECONDS
+    return stats
+
+
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
+    stats = await get_job_stats()
     return templates.TemplateResponse(
-        "index.html", {"request": request, "current_year": datetime.now().year}
+        "index.html",
+        {"request": request, "current_year": datetime.now().year, "job_stats": stats},
     )
 
 
@@ -531,8 +703,10 @@ async def intro(request: Request):
 
 @app.get("/index", response_class=HTMLResponse)
 async def index(request: Request):
+    stats = await get_job_stats()
     return templates.TemplateResponse(
-        "index.html", {"request": request, "current_year": datetime.now().year}
+        "index.html",
+        {"request": request, "current_year": datetime.now().year, "job_stats": stats},
     )
 
 
@@ -548,4 +722,35 @@ async def contact(request: Request):
 
 @app.get("/projects", response_class=HTMLResponse)
 async def projects(request: Request):
-    return templates.TemplateResponse("projects.html", {"request": request})
+    return templates.TemplateResponse(
+        "projects.html", {"request": request, "projects": PROJECTS}
+    )
+
+
+@app.get("/projects/{slug}", response_class=HTMLResponse)
+async def project_detail(request: Request, slug: str):
+    project = PROJECTS_BY_SLUG.get(slug)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    # Suggest a couple of other projects to explore
+    others = [p for p in PROJECTS if p["slug"] != slug][:3]
+    return templates.TemplateResponse(
+        "projects_detail.html",
+        {"request": request, "project": project, "others": others},
+    )
+
+
+@app.get("/robots.txt", response_class=PlainTextResponse)
+async def robots_txt(request: Request):
+    base = str(request.base_url).rstrip("/")
+    return f"User-agent: *\nAllow: /\nSitemap: {base}/sitemap.xml\n"
+
+
+@app.get("/sitemap.xml")
+async def sitemap_xml(request: Request):
+    base = str(request.base_url).rstrip("/")
+    paths = ["/index", "/projects", "/resume", "/contact", "/jobs/linkedin", "/jobs/freework"]
+    paths += [f"/projects/{p['slug']}" for p in PROJECTS]
+    urls = "".join(f"<url><loc>{base}{p}</loc></url>" for p in paths)
+    xml = f'<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{urls}</urlset>'
+    return Response(content=xml, media_type="application/xml")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-fastapi==0.115.14 
-uvicorn==0.34.3 
+fastapi==0.115.14
+starlette==0.46.2
+uvicorn==0.34.3
 motor==3.7.1 
 python-dotenv==1.1.1 
 jinja2==3.1.6

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,34 +1,139 @@
-/* Styles de base */
+/* =========================================================
+   Hocine ABED — Portfolio shared theme (dark)
+   Web Scraping & Reverse Engineering Engineer
+   Centralizes the dark identity reused across every page.
+   ========================================================= */
+
+:root {
+  --bg-base: #020617;
+  --bg-elev: #0b1222;
+  --cyan: #22d3ee;
+  --blue: #3b82f6;
+  --orange: #fb923c;
+  --line: rgba(148, 163, 184, 0.14);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  line-height: 1.6;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  color: #e2e8f0;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(34, 211, 238, 0.16), transparent 42%),
+    radial-gradient(circle at 88% 4%, rgba(251, 146, 60, 0.12), transparent 38%),
+    radial-gradient(circle at 60% 100%, rgba(59, 130, 246, 0.14), transparent 45%),
+    linear-gradient(160deg, #020617 0%, #0b1222 55%, #060b18 100%);
+  background-attachment: fixed;
 }
 
-/* Animation pour les cartes de projet */
-.project-card {
-  transition: all 0.3s ease;
+/* Subtle technical grid overlay — evokes packet captures / data planes */
+.tech-grid {
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.06) 1px, transparent 1px);
+  background-size: 44px 44px;
 }
 
-/* Styles pour la navigation mobile */
-@media (max-width: 768px) {
-  .mobile-menu {
-    display: none;
+.tech-grid--masked {
+  -webkit-mask-image: radial-gradient(circle at center, black 30%, transparent 82%);
+  mask-image: radial-gradient(circle at center, black 30%, transparent 82%);
+}
+
+/* Glowing accent blobs */
+.glow {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(80px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Glass surfaces */
+.glass {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--line);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.glass-strong {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid var(--line);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.card-hover {
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card-hover:hover {
+  transform: translateY(-4px);
+  border-color: rgba(34, 211, 238, 0.45);
+  box-shadow: 0 20px 40px -20px rgba(34, 211, 238, 0.35);
+}
+
+/* Gradient text accent */
+.gradient-text {
+  background: linear-gradient(90deg, #22d3ee, #3b82f6 55%, #fb923c);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Terminal / capture window */
+.terminal {
+  background: rgba(2, 6, 23, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 14px;
+  box-shadow: 0 30px 60px -30px rgba(0, 0, 0, 0.8);
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+}
+
+.terminal-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 9999px;
+  display: inline-block;
+}
+
+/* Timeline connector (resume) */
+.timeline-item:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 23px;
+  top: 46px;
+  bottom: -36px;
+  width: 2px;
+  background: linear-gradient(to bottom, rgba(34, 211, 238, 0.5), rgba(148, 163, 184, 0.1));
+}
+
+/* Reveal animation (respects reduced motion) */
+@keyframes reveal {
+  0% { opacity: 0; transform: translateY(18px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes drift {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-9px); }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+.fade-step { opacity: 0; animation: reveal 0.7s ease forwards; }
+.animate-drift { animation: drift 6s ease-in-out infinite; }
+.cursor-blink { animation: blink 1.1s step-end infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-step, .animate-drift, .cursor-blink {
+    animation: none;
+    opacity: 1;
   }
-
-  .mobile-menu.active {
-    display: block;
-  }
-}
-
-/* Styles pour les liens actifs */
-.active-link {
-  color: #2563eb;
-  font-weight: 600;
-}
-
-/* Styles pour les icônes de compétences */
-.skill-icon {
-  width: 1.5rem;
-  height: 1.5rem;
-  margin-right: 0.5rem;
+  html { scroll-behavior: auto; }
 }

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -4,7 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Contact | Hocine ABED</title>
+  <title>Contact | Hocine ABED — Scraping & Reverse Engineering</title>
+  <meta name="description" content="Get in touch with Hocine ABED — web scraping and reverse-engineering engineer. Available for projects and remote work." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
 
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -13,50 +15,47 @@
         extend: {
           fontFamily: {
             display: ['Sora', 'sans-serif'],
-            body: ['Plus Jakarta Sans', 'sans-serif']
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
           }
         }
       }
     }
   </script>
 
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-
-  <style>
-    body {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      background:
-        radial-gradient(circle at 0% 0%, rgba(14, 165, 233, 0.12), transparent 38%),
-        radial-gradient(circle at 100% 100%, rgba(249, 115, 22, 0.1), transparent 32%),
-        #f8fafc;
-    }
-  </style>
+  <link rel="stylesheet" href="/static/css/style.css" />
 </head>
 
-<body class="text-slate-800">
+<body>
   {% include "partials/navbar.html" %}
 
-  <main class="mx-auto max-w-5xl px-6 py-16">
-    <section class="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm sm:p-10">
+  <main class="relative mx-auto max-w-5xl px-6 py-16">
+    <div class="glow -left-20 top-0 h-64 w-64 bg-cyan-500/20"></div>
+    <div class="glow right-0 bottom-0 h-64 w-64 bg-orange-500/15"></div>
+
+    <section class="glass relative rounded-3xl p-8 shadow-xl sm:p-10">
       <div class="flex flex-col gap-8 md:flex-row md:items-center">
-        <img
-          src="https://media.licdn.com/dms/image/v2/D4E03AQHsoy8Ka5YIng/profile-displayphoto-shrink_200_200/B4EZWjkFfyGgAY-/0/1742205901350?e=2147483647&v=beta&t=gpD57rl_Im2DnjGSpE7SzdLxwTa3pDU6zmBXE9WYhmA"
-          alt="Profile picture of Hocine ABED"
-          class="h-28 w-28 rounded-2xl object-cover shadow-md sm:h-32 sm:w-32" />
+        <div class="shrink-0 rounded-2xl bg-gradient-to-br from-cyan-400 to-blue-600 p-[3px] shadow-lg shadow-cyan-500/20">
+          <img
+            src="https://media.licdn.com/dms/image/v2/D4E03AQHsoy8Ka5YIng/profile-displayphoto-shrink_200_200/B4EZWjkFfyGgAY-/0/1742205901350?e=2147483647&v=beta&t=gpD57rl_Im2DnjGSpE7SzdLxwTa3pDU6zmBXE9WYhmA"
+            alt="Profile picture of Hocine ABED"
+            class="h-28 w-28 rounded-2xl object-cover sm:h-32 sm:w-32" />
+        </div>
 
         <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700">Contact</p>
-          <h1 class="mt-2 font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">Hocine ABED</h1>
-          <p class="mt-3 max-w-2xl text-slate-600">Web scraping engineer focused on robust extraction pipelines, backend APIs, and data automation.</p>
+          <p class="font-code text-xs uppercase tracking-[0.2em] text-cyan-300">// contact</p>
+          <h1 class="mt-2 font-display text-3xl font-extrabold text-white sm:text-4xl">Hocine ABED</h1>
+          <p class="mt-3 max-w-2xl text-slate-300">Web scraping &amp; reverse-engineering engineer focused on robust extraction pipelines, anti-bot bypass, backend APIs, and data automation.</p>
           <div class="mt-5 flex flex-wrap gap-3">
             <a href="https://www.linkedin.com/in/hocine-abed-33979a27/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-lg bg-[#0a66c2] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110">
               <i class="fab fa-linkedin mr-2"></i> LinkedIn
             </a>
-            <a href="https://github.com/housine35" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700">
+            <a href="https://github.com/housine35" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-cyan-400/50 hover:text-cyan-300">
               <i class="fab fa-github mr-2"></i> GitHub
             </a>
-            <a href="mailto:abed.hocine@hotmail.com" class="inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-cyan-500 hover:text-cyan-700">
+            <a href="mailto:abed.hocine@hotmail.com" class="inline-flex items-center rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-cyan-400/50 hover:text-cyan-300">
               <i class="fas fa-envelope mr-2"></i> Email
             </a>
           </div>
@@ -64,32 +63,32 @@
       </div>
 
       <div class="mt-10 grid gap-5 md:grid-cols-2">
-        <article class="rounded-2xl border border-slate-200 bg-slate-50 p-6">
-          <h2 class="font-display text-xl font-bold text-slate-900">About</h2>
-          <p class="mt-3 text-sm leading-relaxed text-slate-600">
-            I build scraping systems that handle anti-bot defenses, pagination at scale, schema drift, and long-running automation jobs.
+        <article class="rounded-2xl border border-white/10 bg-white/5 p-6">
+          <h2 class="font-display text-xl font-bold text-white">About</h2>
+          <p class="mt-3 text-sm leading-relaxed text-slate-400">
+            I build scraping systems that handle anti-bot defenses, reverse-engineered APIs, pagination at scale, schema drift, and long-running automation jobs.
           </p>
         </article>
 
-        <article class="rounded-2xl border border-slate-200 bg-slate-50 p-6">
-          <h2 class="font-display text-xl font-bold text-slate-900">Stack</h2>
-          <ul class="mt-3 grid grid-cols-2 gap-2 text-sm text-slate-700">
+        <article class="rounded-2xl border border-white/10 bg-white/5 p-6">
+          <h2 class="font-display text-xl font-bold text-white">Stack</h2>
+          <ul class="mt-3 grid grid-cols-2 gap-2 text-sm text-slate-300">
             <li>Python</li>
             <li>Playwright</li>
             <li>Scrapy</li>
             <li>FastAPI</li>
             <li>MongoDB</li>
-            <li>Docker</li>
+            <li>Proxyman / Charles</li>
           </ul>
         </article>
       </div>
 
-      <section class="mt-6 rounded-2xl border border-cyan-100 bg-cyan-50 p-6">
-        <h2 class="font-display text-xl font-bold text-cyan-900">Direct Contact</h2>
-        <ul class="mt-4 space-y-3 text-sm text-cyan-950">
-          <li><strong>Email:</strong> <a class="underline" href="mailto:abed.hocine@hotmail.com">abed.hocine@hotmail.com</a></li>
-          <li><strong>Phone:</strong> <a class="underline" href="tel:+33662404764">(+33) 06 62 40 47 64</a></li>
-          <li><strong>Location:</strong> France, open to remote work</li>
+      <section class="mt-6 rounded-2xl border border-cyan-400/20 bg-cyan-400/10 p-6">
+        <h2 class="font-display text-xl font-bold text-cyan-200">Direct Contact</h2>
+        <ul class="mt-4 space-y-3 text-sm text-slate-200">
+          <li><strong class="text-white">Email:</strong> <a class="underline decoration-cyan-400/50 hover:text-cyan-300" href="mailto:abed.hocine@hotmail.com">abed.hocine@hotmail.com</a></li>
+          <li><strong class="text-white">Phone:</strong> <a class="underline decoration-cyan-400/50 hover:text-cyan-300" href="tel:+33662404764">(+33) 06 62 40 47 64</a></li>
+          <li><strong class="text-white">Location:</strong> France, open to remote work</li>
         </ul>
       </section>
     </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,35 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Portfolio | Hocine ABED</title>
+  <title>Hocine ABED | Web Scraping & Reverse Engineering Engineer</title>
+  <meta name="description" content="Software engineer specialized in large-scale web scraping and reverse engineering: anti-bot bypass, mobile/web API analysis, request signing, and resilient data pipelines." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Hocine ABED | Web Scraping & Reverse Engineering Engineer" />
+  <meta property="og:description" content="Anti-bot bypass, API reverse engineering, request signing, and resilient data pipelines at scale." />
+  <meta property="og:image" content="https://media.licdn.com/dms/image/v2/D4E03AQHsoy8Ka5YIng/profile-displayphoto-shrink_200_200/B4EZWjkFfyGgAY-/0/1742205901350?e=2147483647&v=beta&t=gpD57rl_Im2DnjGSpE7SzdLxwTa3pDU6zmBXE9WYhmA" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Hocine ABED | Web Scraping & Reverse Engineering Engineer" />
+  <meta name="twitter:description" content="Anti-bot bypass, API reverse engineering, request signing, and resilient data pipelines at scale." />
+
+  <!-- Structured data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Hocine ABED",
+    "jobTitle": "Web Scraping & Reverse Engineering Engineer",
+    "email": "mailto:abed.hocine@hotmail.com",
+    "url": "https://www.linkedin.com/in/hocine-abed-33979a27/",
+    "sameAs": [
+      "https://www.linkedin.com/in/hocine-abed-33979a27/",
+      "https://github.com/housine35"
+    ],
+    "knowsAbout": ["Web Scraping", "Reverse Engineering", "Anti-bot Evasion", "Python", "FastAPI", "MongoDB", "Data Pipelines"]
+  }
+  </script>
 
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -13,124 +41,156 @@
         extend: {
           fontFamily: {
             display: ['Sora', 'sans-serif'],
-            body: ['Plus Jakarta Sans', 'sans-serif']
-          },
-          keyframes: {
-            reveal: {
-              '0%': { opacity: 0, transform: 'translateY(18px)' },
-              '100%': { opacity: 1, transform: 'translateY(0)' }
-            }
-          },
-          animation: {
-            reveal: 'reveal .7s ease forwards'
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
           }
         }
       }
     }
   </script>
 
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-
-  <style>
-    body {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      background:
-        radial-gradient(circle at 15% 0%, rgba(14, 165, 233, 0.12), transparent 38%),
-        radial-gradient(circle at 90% 20%, rgba(249, 115, 22, 0.1), transparent 36%),
-        #f8fafc;
-    }
-
-    .hero-mesh {
-      background-image: linear-gradient(rgba(15, 23, 42, 0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px);
-      background-size: 42px 42px;
-    }
-
-    .fade-step {
-      animation: reveal .7s ease forwards;
-    }
-  </style>
+  <link rel="stylesheet" href="/static/css/style.css" />
 </head>
 
-<body class="text-slate-800">
+<body>
   {% include "partials/navbar.html" %}
 
-  <section class="relative overflow-hidden border-b border-slate-200 bg-white/70">
-    <div class="hero-mesh absolute inset-0 opacity-30"></div>
+  <!-- Hero -->
+  <section class="relative overflow-hidden border-b border-white/10">
+    <div class="tech-grid tech-grid--masked absolute inset-0 opacity-60"></div>
+    <div class="glow -left-24 top-10 h-72 w-72 bg-cyan-500/20"></div>
+    <div class="glow -right-24 top-24 h-80 w-80 bg-orange-500/20"></div>
+
     <div class="relative mx-auto max-w-7xl px-6 py-20 sm:py-24">
-      <div class="grid items-center gap-10 lg:grid-cols-[1.3fr_1fr]">
+      <div class="grid items-center gap-12 lg:grid-cols-[1.25fr_1fr]">
         <div>
-          <p class="fade-step text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700" style="animation-delay:.05s">Data Extraction Specialist</p>
-          <h1 class="fade-step mt-4 max-w-3xl font-display text-4xl font-extrabold leading-tight text-slate-900 sm:text-6xl" style="animation-delay:.15s">
-            Building resilient web scrapers and automation systems.
+          <p class="fade-step inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 font-code text-xs uppercase tracking-[0.2em] text-cyan-300" style="animation-delay:.05s">
+            <span class="inline-block h-1.5 w-1.5 rounded-full bg-cyan-400"></span>
+            Scraping &amp; Reverse Engineering
+          </p>
+          <h1 class="fade-step mt-5 max-w-3xl font-display text-4xl font-extrabold leading-tight text-white sm:text-6xl" style="animation-delay:.15s">
+            I make closed systems <span class="gradient-text">give up their data</span>.
           </h1>
-          <p class="fade-step mt-6 max-w-2xl text-base leading-relaxed text-slate-600 sm:text-lg" style="animation-delay:.3s">
-            I design pipelines that collect data from complex websites, normalize it, and deliver business-ready output through APIs and dashboards.
+          <p class="fade-step mt-6 max-w-2xl text-base leading-relaxed text-slate-300 sm:text-lg" style="animation-delay:.3s">
+            I reverse-engineer web &amp; mobile APIs, defeat anti-bot defenses, and build resilient pipelines that turn protected, fast-changing sources into clean, business-ready data.
           </p>
 
           <div class="fade-step mt-8 flex flex-wrap gap-3" style="animation-delay:.45s">
-            <a href="/projects" class="inline-flex items-center rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-700">
+            <a href="/projects" class="inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:brightness-110">
               Explore Projects
               <i class="fas fa-arrow-right ml-2"></i>
             </a>
-            <a href="/resume" class="inline-flex items-center rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-cyan-500 hover:text-cyan-700">
+            <a href="/resume" class="inline-flex items-center rounded-xl border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-400/50 hover:text-cyan-300">
               View Resume
             </a>
           </div>
         </div>
 
-        <aside class="fade-step rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" style="animation-delay:.55s">
-          <p class="text-sm font-semibold uppercase tracking-wider text-slate-500">Core Stack</p>
-          <div class="mt-4 grid grid-cols-2 gap-3 text-sm">
-            <div class="rounded-lg bg-slate-50 px-3 py-2">Python</div>
-            <div class="rounded-lg bg-slate-50 px-3 py-2">Playwright</div>
-            <div class="rounded-lg bg-slate-50 px-3 py-2">Scrapy</div>
-            <div class="rounded-lg bg-slate-50 px-3 py-2">FastAPI</div>
-            <div class="rounded-lg bg-slate-50 px-3 py-2">MongoDB</div>
-            <div class="rounded-lg bg-slate-50 px-3 py-2">Docker</div>
+        <!-- Terminal capture window -->
+        <aside class="fade-step terminal overflow-hidden" style="animation-delay:.55s">
+          <div class="flex items-center gap-2 border-b border-white/10 px-4 py-3">
+            <span class="terminal-dot bg-red-400/80"></span>
+            <span class="terminal-dot bg-amber-400/80"></span>
+            <span class="terminal-dot bg-emerald-400/80"></span>
+            <span class="ml-2 font-code text-xs text-slate-400">capture — api.target.com</span>
           </div>
-          <div class="mt-6 rounded-xl border border-cyan-100 bg-cyan-50 p-4">
-            <p class="text-sm text-cyan-900">
-              Focus areas: anti-bot handling, pagination at scale, change-tolerant parsers, scheduled ETL jobs.
-            </p>
+          <div class="space-y-1.5 px-4 py-4 font-code text-[12.5px] leading-relaxed">
+            <p class="text-slate-500"># intercept + replay signed request</p>
+            <p class="text-cyan-300">POST <span class="text-slate-200">/v2/feed</span> <span class="text-slate-500">HTTP/2</span></p>
+            <p class="text-slate-300">x-signature: <span class="text-orange-300">a3f9…c1b2</span></p>
+            <p class="text-slate-300">x-device-id: <span class="text-orange-300">reversed ✓</span></p>
+            <p class="text-emerald-300">← 200 OK <span class="text-slate-400">· 1,284 records</span></p>
+            <p class="text-slate-300">parsing<span class="text-slate-500">…</span> normalized → mongo</p>
+            <p class="text-slate-200">$ <span class="cursor-blink">▋</span></p>
           </div>
         </aside>
+      </div>
+
+      <!-- Metrics strip -->
+      <div class="fade-step mt-16 grid grid-cols-2 gap-4 sm:grid-cols-4" style="animation-delay:.65s">
+        <!-- Live counter pulled from the real scraping database -->
+        <div class="glass rounded-2xl px-5 py-5 text-center ring-1 ring-cyan-400/30">
+          <p class="font-display text-2xl font-extrabold text-white sm:text-3xl">
+            {% if job_stats and job_stats.total %}{{ "{:,}".format(job_stats.total) }}{% else %}70k+{% endif %}
+          </p>
+          <p class="mt-1 flex items-center justify-center gap-1.5 text-xs uppercase tracking-wider text-slate-400">
+            <span class="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400"></span>
+            jobs indexed · live
+          </p>
+        </div>
+        {% set stats = [
+          {"value": "30 min", "label": "refresh cadence"},
+          {"value": ">98%", "label": "anti-bot success rate"},
+          {"value": "5+ yrs", "label": "in data extraction"}
+        ] %}
+        {% for s in stats %}
+        <div class="glass rounded-2xl px-5 py-5 text-center">
+          <p class="font-display text-2xl font-extrabold text-white sm:text-3xl">{{ s.value }}</p>
+          <p class="mt-1 text-xs uppercase tracking-wider text-slate-400">{{ s.label }}</p>
+        </div>
+        {% endfor %}
       </div>
     </div>
   </section>
 
   <main class="mx-auto max-w-7xl px-6 py-16">
-    <section class="grid gap-5 md:grid-cols-3">
-      <a href="/jobs/linkedin" class="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
-        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-100 text-cyan-700"><i class="fab fa-linkedin-in"></i></div>
-        <h2 class="mt-4 font-display text-xl font-bold text-slate-900">LinkedIn Job Finder</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-600">Filter jobs by country, date, and source with fast lookup and pagination.</p>
-        <span class="mt-4 inline-flex items-center text-sm font-semibold text-cyan-700">Open <i class="fas fa-arrow-right ml-2 text-xs"></i></span>
+    <!-- What I do -->
+    <section>
+      <p class="font-code text-xs uppercase tracking-[0.2em] text-cyan-300">// capabilities</p>
+      <h2 class="mt-3 font-display text-2xl font-bold text-white sm:text-3xl">From locked-down source to clean dataset</h2>
+      <div class="mt-8 grid gap-5 md:grid-cols-3">
+        {% set caps = [
+          {"icon": "fas fa-fingerprint", "color": "cyan", "title": "Reverse Engineering", "desc": "Web & mobile API analysis, request signing, token/cookie flows, payload decryption with Proxyman, Charles & Frida."},
+          {"icon": "fas fa-shield-halved", "color": "orange", "title": "Anti-Bot Evasion", "desc": "TLS/JA3 fingerprinting, headless detection bypass, proxy rotation, and human-like automation at scale."},
+          {"icon": "fas fa-diagram-project", "color": "blue", "title": "Resilient Pipelines", "desc": "Change-tolerant parsers, scheduled ETL, normalization, and API-ready output backed by MongoDB & Elasticsearch."}
+        ] %}
+        {% for c in caps %}
+        <article class="glass card-hover rounded-2xl p-6">
+          <div class="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-{{ c.color }}-400/15 text-{{ c.color }}-300">
+            <i class="{{ c.icon }}"></i>
+          </div>
+          <h3 class="mt-4 font-display text-lg font-bold text-white">{{ c.title }}</h3>
+          <p class="mt-2 text-sm leading-relaxed text-slate-400">{{ c.desc }}</p>
+        </article>
+        {% endfor %}
+      </div>
+    </section>
+
+    <!-- Quick links -->
+    <section class="mt-16 grid gap-5 md:grid-cols-3">
+      <a href="/jobs/linkedin" class="glass card-hover group rounded-2xl p-6">
+        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-400/15 text-cyan-300"><i class="fab fa-linkedin-in"></i></div>
+        <h2 class="mt-4 font-display text-xl font-bold text-white">LinkedIn Job Finder</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-400">Filter jobs by country, date, and source with fast lookup and pagination.</p>
+        <span class="mt-4 inline-flex items-center text-sm font-semibold text-cyan-300">Open <i class="fas fa-arrow-right ml-2 text-xs"></i></span>
       </a>
 
-      <a href="/jobs/freework" class="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
-        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700"><i class="fas fa-briefcase"></i></div>
-        <h2 class="mt-4 font-display text-xl font-bold text-slate-900">Freework Explorer</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-600">Track freelance opportunities and download daily snapshots as CSV.</p>
-        <span class="mt-4 inline-flex items-center text-sm font-semibold text-emerald-700">Open <i class="fas fa-arrow-right ml-2 text-xs"></i></span>
+      <a href="/jobs/freework" class="glass card-hover group rounded-2xl p-6">
+        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-400/15 text-emerald-300"><i class="fas fa-briefcase"></i></div>
+        <h2 class="mt-4 font-display text-xl font-bold text-white">Freework Explorer</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-400">Track freelance opportunities and download daily snapshots as CSV.</p>
+        <span class="mt-4 inline-flex items-center text-sm font-semibold text-emerald-300">Open <i class="fas fa-arrow-right ml-2 text-xs"></i></span>
       </a>
 
-      <a href="/projects" class="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
-        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-amber-100 text-amber-700"><i class="fas fa-layer-group"></i></div>
-        <h2 class="mt-4 font-display text-xl font-bold text-slate-900">Project Collection</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-600">Review scraping systems across social platforms, jobs, and public data sources.</p>
-        <span class="mt-4 inline-flex items-center text-sm font-semibold text-amber-700">Open <i class="fas fa-arrow-right ml-2 text-xs"></i></span>
+      <a href="/projects" class="glass card-hover group rounded-2xl p-6">
+        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-amber-400/15 text-amber-300"><i class="fas fa-layer-group"></i></div>
+        <h2 class="mt-4 font-display text-xl font-bold text-white">Project Collection</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-400">Review scraping & reverse-engineering systems across social, jobs, and public data.</p>
+        <span class="mt-4 inline-flex items-center text-sm font-semibold text-amber-300">Open <i class="fas fa-arrow-right ml-2 text-xs"></i></span>
       </a>
     </section>
 
-    <section class="mt-16 rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+    <!-- CTA -->
+    <section class="mt-16 overflow-hidden rounded-2xl border border-cyan-400/20 bg-gradient-to-r from-cyan-500/10 via-blue-500/10 to-transparent p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Contact</p>
-          <h3 class="mt-2 font-display text-2xl font-bold text-slate-900">Need data from a hard-to-scrape website?</h3>
-          <p class="mt-2 text-sm text-slate-600">I can help you architect and ship stable scraping pipelines quickly.</p>
+          <p class="font-code text-xs uppercase tracking-[0.2em] text-cyan-300">// contact</p>
+          <h3 class="mt-2 font-display text-2xl font-bold text-white">Need data from a site that fights back?</h3>
+          <p class="mt-2 text-sm text-slate-300">I architect and ship stable scraping &amp; reverse-engineering pipelines, fast.</p>
         </div>
-        <a href="/contact" class="inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-500 to-blue-700 px-5 py-3 text-sm font-semibold text-white transition hover:brightness-110">
+        <a href="/contact" class="inline-flex shrink-0 items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:brightness-110">
           Start a conversation
           <i class="fas fa-paper-plane ml-2"></i>
         </a>

--- a/templates/intro.html
+++ b/templates/intro.html
@@ -61,14 +61,14 @@
 
   <main class="relative mx-auto flex min-h-screen w-full max-w-6xl items-center px-6 py-16">
     <div class="w-full rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl sm:p-12">
-      <p class="font-code text-xs uppercase tracking-[0.25em] text-cyan-300/90 [animation-delay:.05s] animate-rise">Web Scraper Portfolio</p>
+      <p class="font-code text-xs uppercase tracking-[0.25em] text-cyan-300/90 [animation-delay:.05s] animate-rise">Scraping &amp; Reverse Engineering Portfolio</p>
 
       <h1 class="mt-5 max-w-3xl font-display text-4xl font-extrabold leading-tight text-white [animation-delay:.2s] animate-rise sm:text-6xl">
-        I build scrapers that turn noisy pages into clean data products.
+        I reverse-engineer closed systems and turn them into clean data products.
       </h1>
 
       <p class="mt-6 max-w-2xl text-base leading-relaxed text-slate-300 [animation-delay:.35s] animate-rise sm:text-lg">
-        Fast extraction, resilient parsing, automation pipelines, and API-ready output for jobs, social media, and public data.
+        API reverse engineering, anti-bot bypass, resilient parsing, automation pipelines, and API-ready output for jobs, social media, and public data.
       </p>
 
       <div class="mt-8 flex flex-wrap items-center gap-3 [animation-delay:.5s] animate-rise">

--- a/templates/jobs/freework.html
+++ b/templates/jobs/freework.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Freework Job Listings | Hocine ABED</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
 
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -13,140 +14,126 @@
         extend: {
           fontFamily: {
             display: ['Sora', 'sans-serif'],
-            body: ['Plus Jakarta Sans', 'sans-serif']
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
           }
         }
       }
     }
   </script>
 
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="/static/css/style.css" />
 
   <style>
-    body {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      background:
-        radial-gradient(circle at 15% 0%, rgba(14, 165, 233, 0.12), transparent 38%),
-        radial-gradient(circle at 90% 20%, rgba(16, 185, 129, 0.1), transparent 36%),
-        #f8fafc;
-    }
-
-    .modal {
-      transition: opacity .2s ease-in-out;
-    }
-
-    .modal-hidden {
-      opacity: 0;
-      pointer-events: none;
-    }
-
-    .modal-visible {
-      opacity: 1;
-      pointer-events: auto;
-    }
+    .modal { transition: opacity .2s ease-in-out; }
+    .modal-hidden { opacity: 0; pointer-events: none; }
+    .modal-visible { opacity: 1; pointer-events: auto; }
   </style>
 </head>
 
-<body class="text-slate-800">
+<body>
   {% include "partials/navbar.html" %}
 
-  <main class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-    <header class="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-      <p class="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-700">Freework Source</p>
-      <h1 class="mt-3 font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">Freework Remote Jobs</h1>
-      <p class="mt-3 max-w-3xl text-sm leading-relaxed text-slate-600 sm:text-base">
-        Browse freelance opportunities by remote mode, publication date, and scraping category.
+  <main class="relative mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+    <div class="glow -left-20 top-0 h-64 w-64 bg-emerald-500/20"></div>
+
+    <header class="glass relative rounded-3xl p-8 shadow-sm">
+      <p class="font-code text-xs uppercase tracking-[0.2em] text-emerald-300">// freework source</p>
+      <h1 class="mt-3 font-display text-3xl font-extrabold text-white sm:text-4xl">Freework Remote Jobs</h1>
+      <p class="mt-3 max-w-3xl text-sm leading-relaxed text-slate-300 sm:text-base">
+        Browse freelance opportunities by remote mode, publication date, location, and scraping category.
       </p>
 
       <div class="mt-6 flex flex-wrap gap-3">
-        <a href="/jobs/linkedin" class="inline-flex items-center rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-700">
+        <a href="/jobs/linkedin" class="inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:brightness-110">
           <i class="fas fa-briefcase mr-2"></i> View LinkedIn Jobs
         </a>
-        <a href="https://github.com/housine35/freework-job-scraper" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-emerald-500 hover:text-emerald-700">
+        <a href="https://github.com/housine35/freework-job-scraper" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-xl border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-emerald-400/50 hover:text-emerald-300">
           <i class="fab fa-github mr-2"></i> Freework Scraper Repo
         </a>
-        <button id="download-btn" class="inline-flex items-center rounded-xl bg-emerald-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-emerald-700">
+        <button id="download-btn" class="inline-flex items-center rounded-xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400">
           <i class="fas fa-download mr-2"></i> Download Today's CSV
         </button>
       </div>
     </header>
 
-    <div id="email-modal" class="modal modal-hidden fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-      <div class="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
-        <h2 class="font-display text-xl font-bold text-slate-900">Email Confirmation</h2>
-        <p class="mt-2 text-sm text-slate-600">Enter your email to download today's CSV snapshot.</p>
+    <div id="email-modal" class="modal modal-hidden fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div class="glass-strong w-full max-w-md rounded-2xl p-6 shadow-xl">
+        <h2 class="font-display text-xl font-bold text-white">Email Confirmation</h2>
+        <p class="mt-2 text-sm text-slate-300">Enter your email to download today's CSV snapshot.</p>
 
         <form id="email-form" action="/jobs/freework/download-today-with-email" method="post" class="mt-5">
-          <label for="email-input" class="mb-2 block text-sm font-medium text-slate-700">Email Address</label>
-          <input type="email" id="email-input" name="email" required placeholder="your.email@example.com" class="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100" />
-          <p id="email-error" class="mt-1 hidden text-sm text-red-600">Please enter a valid email address.</p>
+          <label for="email-input" class="mb-2 block text-sm font-medium text-slate-300">Email Address</label>
+          <input type="email" id="email-input" name="email" required placeholder="your.email@example.com" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 placeholder-slate-500 focus:border-emerald-400/60 focus:outline-none focus:ring-2 focus:ring-emerald-500/20" />
+          <p id="email-error" class="mt-1 hidden text-sm text-red-400">Please enter a valid email address.</p>
 
           <div class="mt-5 flex justify-end gap-2">
-            <button type="button" id="cancel-btn" class="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Cancel</button>
-            <button type="submit" id="submit-email-btn" class="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700">Download</button>
+            <button type="button" id="cancel-btn" class="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-slate-300 hover:text-white">Cancel</button>
+            <button type="submit" id="submit-email-btn" class="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-400">Download</button>
           </div>
         </form>
       </div>
     </div>
 
-    <section class="mt-8 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <section class="mt-8 glass rounded-2xl p-6 shadow-sm">
       <form method="get" action="/jobs/freework" id="filter-form" class="grid gap-4 md:grid-cols-6">
         <div>
-          <label for="remote-mode-filter" class="mb-2 block text-sm font-medium text-slate-700">Remote Mode</label>
-          <select id="remote-mode-filter" name="remote_mode" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100">
-            <option value="all">All</option>
+          <label for="remote-mode-filter" class="mb-2 block text-sm font-medium text-slate-300">Remote Mode</label>
+          <select id="remote-mode-filter" name="remote_mode" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-emerald-400/60 focus:outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <option value="all" class="bg-slate-900">All</option>
             {% for mode in unique_remote_modes %}
-            <option value="{{ mode }}" {% if mode==selected_remote_mode %}selected{% endif %}>{{ mode | capitalize }}</option>
+            <option value="{{ mode }}" class="bg-slate-900" {% if mode==selected_remote_mode %}selected{% endif %}>{{ mode | capitalize }}</option>
             {% endfor %}
           </select>
         </div>
 
         <div>
-          <label for="date-filter" class="mb-2 block text-sm font-medium text-slate-700">Date</label>
-          <select id="date-filter" name="date" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100">
-            <option value="all">All Dates</option>
+          <label for="date-filter" class="mb-2 block text-sm font-medium text-slate-300">Date</label>
+          <select id="date-filter" name="date" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-emerald-400/60 focus:outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <option value="all" class="bg-slate-900">All Dates</option>
             {% for date in unique_dates %}
-            <option value="{{ date }}" {% if date==selected_date %}selected{% endif %}>{{ date }}</option>
+            <option value="{{ date }}" class="bg-slate-900" {% if date==selected_date %}selected{% endif %}>{{ date }}</option>
             {% endfor %}
           </select>
         </div>
 
         <div>
-          <label for="type-filter" class="mb-2 block text-sm font-medium text-slate-700">Type</label>
-          <select id="type-filter" name="type" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100">
-            <option value="all" {% if selected_type=="all" %}selected{% endif %}>All</option>
-            <option value="scraping" {% if selected_type=="scraping" %}selected{% endif %}>Scraping</option>
+          <label for="type-filter" class="mb-2 block text-sm font-medium text-slate-300">Type</label>
+          <select id="type-filter" name="type" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-emerald-400/60 focus:outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <option value="all" class="bg-slate-900" {% if selected_type=="all" %}selected{% endif %}>All</option>
+            <option value="scraping" class="bg-slate-900" {% if selected_type=="scraping" %}selected{% endif %}>Scraping</option>
           </select>
         </div>
 
         <div>
-          <label for="department-filter" class="mb-2 block text-sm font-medium text-slate-700">Department</label>
-          <select id="department-filter" name="department" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100">
-            <option value="all">All Departments</option>
+          <label for="department-filter" class="mb-2 block text-sm font-medium text-slate-300">Department</label>
+          <select id="department-filter" name="department" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-emerald-400/60 focus:outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <option value="all" class="bg-slate-900">All Departments</option>
             {% for department in unique_departments %}
-            <option value="{{ department }}" {% if department==selected_department %}selected{% endif %}>{{ department }}</option>
+            <option value="{{ department }}" class="bg-slate-900" {% if department==selected_department %}selected{% endif %}>{{ department }}</option>
             {% endfor %}
           </select>
         </div>
 
         <div>
-          <label for="city-filter" class="mb-2 block text-sm font-medium text-slate-700">City</label>
-          <select id="city-filter" name="city" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100">
-            <option value="all">All Cities</option>
+          <label for="city-filter" class="mb-2 block text-sm font-medium text-slate-300">City</label>
+          <select id="city-filter" name="city" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-emerald-400/60 focus:outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <option value="all" class="bg-slate-900">All Cities</option>
             {% for city in unique_cities %}
-            <option value="{{ city }}" {% if city==selected_city %}selected{% endif %}>{{ city }}</option>
+            <option value="{{ city }}" class="bg-slate-900" {% if city==selected_city %}selected{% endif %}>{{ city }}</option>
             {% endfor %}
           </select>
         </div>
 
         <div>
-          <label for="per-page" class="mb-2 block text-sm font-medium text-slate-700">Per Page</label>
-          <select id="per-page" name="per_page" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100">
-            <option value="10" {% if per_page==10 %}selected{% endif %}>10</option>
-            <option value="20" {% if per_page==20 %}selected{% endif %}>20</option>
-            <option value="50" {% if per_page==50 %}selected{% endif %}>50</option>
-            <option value="100" {% if per_page==100 %}selected{% endif %}>100</option>
+          <label for="per-page" class="mb-2 block text-sm font-medium text-slate-300">Per Page</label>
+          <select id="per-page" name="per_page" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-emerald-400/60 focus:outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <option value="10" class="bg-slate-900" {% if per_page==10 %}selected{% endif %}>10</option>
+            <option value="20" class="bg-slate-900" {% if per_page==20 %}selected{% endif %}>20</option>
+            <option value="50" class="bg-slate-900" {% if per_page==50 %}selected{% endif %}>50</option>
+            <option value="100" class="bg-slate-900" {% if per_page==100 %}selected{% endif %}>100</option>
           </select>
         </div>
 
@@ -154,22 +141,22 @@
       </form>
     </section>
 
-    <section class="mt-6 flex items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm">
-      <p class="text-slate-700">
+    <section class="mt-6 flex items-center justify-between gap-4 rounded-2xl glass px-4 py-3 text-sm shadow-sm">
+      <p class="text-slate-300">
         {% if selected_remote_mode != "all" or selected_date != "all" or selected_type != "all" or selected_department != "all" or selected_city != "all" %}
-        <span class="font-semibold text-emerald-700">{{ filtered_jobs_count }}</span> filtered jobs
+        <span class="font-semibold text-emerald-300">{{ filtered_jobs_count }}</span> filtered jobs
         {% else %}
-        Showing <span class="font-semibold text-emerald-700">{{ filtered_jobs_count }}</span> jobs
+        Showing <span class="font-semibold text-emerald-300">{{ filtered_jobs_count }}</span> jobs
         {% endif %}
         <span class="text-slate-500">(of {{ total_jobs }} total)</span>
       </p>
     </section>
 
-    <section class="mt-6 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <section class="mt-6 overflow-hidden rounded-2xl glass shadow-sm">
       {% if jobs|length > 0 %}
       <div class="overflow-x-auto">
         <table class="min-w-full text-sm">
-          <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+          <thead class="bg-white/5 text-xs uppercase tracking-wide text-slate-400">
             <tr>
               <th class="px-5 py-4 text-left">Job</th>
               <th class="px-5 py-4 text-left">Company</th>
@@ -177,38 +164,38 @@
               <th class="px-5 py-4 text-right">Actions</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-slate-200">
+          <tbody class="divide-y divide-white/5">
             {% for job in jobs %}
-            <tr class="transition hover:bg-slate-50">
+            <tr class="transition hover:bg-white/5">
               <td class="px-5 py-4">
-                <p class="font-semibold text-slate-900">{{ job.title }}</p>
+                <p class="font-semibold text-white">{{ job.title }}</p>
                 <div class="mt-2 flex flex-wrap gap-2">
-                  <span class="rounded-full bg-cyan-100 px-2.5 py-1 text-xs font-medium text-cyan-800">{{ job.remote_mode | capitalize }}</span>
+                  <span class="rounded-full bg-cyan-400/15 px-2.5 py-1 text-xs font-medium text-cyan-200">{{ job.remote_mode | capitalize }}</span>
                   {% if job.daily_salary %}
-                  <span class="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-medium text-emerald-800">{{ job.daily_salary }}/day</span>
+                  <span class="rounded-full bg-emerald-400/15 px-2.5 py-1 text-xs font-medium text-emerald-200">{{ job.daily_salary }}/day</span>
                   {% endif %}
                 </div>
               </td>
               <td class="px-5 py-4">
-                <p class="font-medium text-slate-800">{{ job.company }}</p>
+                <p class="font-medium text-slate-200">{{ job.company }}</p>
                 <p class="text-sm text-slate-500">{{ job.location }}</p>
                 {% if job.department or job.city %}
                 <div class="mt-2 flex flex-wrap gap-2">
-                  {% if job.department %}<span class="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">{{ job.department }}</span>{% endif %}
-                  {% if job.city %}<span class="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">{{ job.city }}</span>{% endif %}
+                  {% if job.department %}<span class="rounded-full bg-white/5 px-2.5 py-1 text-xs font-medium text-slate-300">{{ job.department }}</span>{% endif %}
+                  {% if job.city %}<span class="rounded-full bg-white/5 px-2.5 py-1 text-xs font-medium text-slate-300">{{ job.city }}</span>{% endif %}
                 </div>
                 {% endif %}
               </td>
-              <td class="px-5 py-4 text-slate-600">
+              <td class="px-5 py-4 text-slate-400">
                 <p>Published: {{ job.published_at | relative_time }}</p>
-                {% if job.daily_salary %}<p>Rate: <span class="font-semibold text-emerald-700">{{ job.daily_salary }}</span></p>{% endif %}
+                {% if job.daily_salary %}<p>Rate: <span class="font-semibold text-emerald-300">{{ job.daily_salary }}</span></p>{% endif %}
               </td>
               <td class="px-5 py-4 text-right">
                 <div class="flex flex-col items-end gap-2">
-                  <a href="/jobs/freework/{{ job.id }}?return_page={{ page }}&per_page={{ per_page }}" class="inline-flex items-center rounded-lg bg-emerald-600 px-4 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700">
+                  <a href="/jobs/freework/{{ job.id }}?return_page={{ page }}&per_page={{ per_page }}" class="inline-flex items-center rounded-lg bg-emerald-500 px-4 py-2 text-xs font-semibold text-slate-950 transition hover:bg-emerald-400">
                     <i class="fas fa-info-circle mr-2"></i> Details
                   </a>
-                  <a href="{{ job.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50">
+                  <a href="{{ job.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold text-slate-200 transition hover:border-emerald-400/50 hover:text-emerald-300">
                     <i class="fas fa-external-link-alt mr-2"></i> Apply
                   </a>
                 </div>
@@ -219,23 +206,23 @@
         </table>
       </div>
       {% else %}
-      <div class="px-6 py-16 text-center text-slate-500">
-        <p class="text-lg font-semibold text-slate-700">No jobs found</p>
+      <div class="px-6 py-16 text-center text-slate-400">
+        <p class="text-lg font-semibold text-slate-200">No jobs found</p>
         <p class="mt-1 text-sm">Try changing your filters to see results.</p>
       </div>
       {% endif %}
     </section>
 
     {% if jobs|length > 0 %}
-    <section class="mt-6 flex flex-col justify-between gap-4 rounded-2xl border border-slate-200 bg-white p-4 text-sm shadow-sm sm:flex-row sm:items-center">
-      <p class="text-slate-600">
-        Showing <span class="font-semibold">{{ ((page - 1) * per_page) + 1 }}</span> to
-        <span class="font-semibold">{{ [page * per_page, filtered_jobs_count]|min }}</span> of
-        <span class="font-semibold">{{ filtered_jobs_count }}</span> results
+    <section class="mt-6 flex flex-col justify-between gap-4 rounded-2xl glass p-4 text-sm shadow-sm sm:flex-row sm:items-center">
+      <p class="text-slate-400">
+        Showing <span class="font-semibold text-slate-200">{{ ((page - 1) * per_page) + 1 }}</span> to
+        <span class="font-semibold text-slate-200">{{ [page * per_page, filtered_jobs_count]|min }}</span> of
+        <span class="font-semibold text-slate-200">{{ filtered_jobs_count }}</span> results
       </p>
       <div class="flex gap-2">
-        <a href="?remote_mode={{ selected_remote_mode }}&date={{ selected_date }}&type={{ selected_type }}&department={{ selected_department }}&city={{ selected_city }}&page={{ page - 1 if page > 1 else 1 }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page <= 1 %}cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400{% else %}border-slate-300 bg-white text-slate-700 hover:bg-slate-50{% endif %}">Previous</a>
-        <a href="?remote_mode={{ selected_remote_mode }}&date={{ selected_date }}&type={{ selected_type }}&department={{ selected_department }}&city={{ selected_city }}&page={{ page + 1 if page < total_pages else total_pages }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page >= total_pages %}cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400{% else %}border-slate-300 bg-white text-slate-700 hover:bg-slate-50{% endif %}">Next</a>
+        <a href="?remote_mode={{ selected_remote_mode }}&date={{ selected_date }}&type={{ selected_type }}&department={{ selected_department }}&city={{ selected_city }}&page={{ page - 1 if page > 1 else 1 }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page <= 1 %}cursor-not-allowed border-white/5 bg-white/5 text-slate-600{% else %}border-white/15 bg-white/5 text-slate-200 hover:border-emerald-400/50 hover:text-emerald-300{% endif %}">Previous</a>
+        <a href="?remote_mode={{ selected_remote_mode }}&date={{ selected_date }}&type={{ selected_type }}&department={{ selected_department }}&city={{ selected_city }}&page={{ page + 1 if page < total_pages else total_pages }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page >= total_pages %}cursor-not-allowed border-white/5 bg-white/5 text-slate-600{% else %}border-white/15 bg-white/5 text-slate-200 hover:border-emerald-400/50 hover:text-emerald-300{% endif %}">Next</a>
       </div>
     </section>
     {% endif %}

--- a/templates/jobs/freework_detail.html
+++ b/templates/jobs/freework_detail.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ job.title }} - Freework Job Details</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
 
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -13,122 +14,116 @@
         extend: {
           fontFamily: {
             display: ['Sora', 'sans-serif'],
-            body: ['Plus Jakarta Sans', 'sans-serif']
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
           }
         }
       }
     }
   </script>
 
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-
-  <style>
-    body {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      background:
-        radial-gradient(circle at 15% 0%, rgba(14, 165, 233, 0.12), transparent 38%),
-        radial-gradient(circle at 90% 20%, rgba(16, 185, 129, 0.1), transparent 36%),
-        #f8fafc;
-    }
-  </style>
+  <link rel="stylesheet" href="/static/css/style.css" />
 </head>
 
-<body class="text-slate-800">
+<body>
   {% include "partials/navbar.html" %}
 
-  <main class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+  <main class="relative mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+    <div class="glow -left-20 top-0 h-64 w-64 bg-emerald-500/20"></div>
+
     <div class="mb-5">
-      <a href="/jobs/freework?page={{ return_page }}&per_page={{ per_page }}" class="inline-flex items-center text-sm font-medium text-slate-600 transition hover:text-emerald-700">
+      <a href="/jobs/freework?page={{ return_page }}&per_page={{ per_page }}" class="inline-flex items-center text-sm font-medium text-slate-400 transition hover:text-emerald-300">
         <i class="fas fa-arrow-left mr-2"></i> Back to listings
       </a>
     </div>
 
-    <section class="rounded-3xl border border-slate-200 bg-white p-7 shadow-sm sm:p-8">
+    <section class="glass relative rounded-3xl p-7 shadow-sm sm:p-8">
       <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
         <div>
-          <h1 class="font-display text-2xl font-extrabold text-slate-900 sm:text-3xl">{{ job.title }}</h1>
-          <p class="mt-2 text-lg font-medium text-slate-700">{{ job.company }}</p>
+          <h1 class="font-display text-2xl font-extrabold text-white sm:text-3xl">{{ job.title }}</h1>
+          <p class="mt-2 text-lg font-medium text-slate-300">{{ job.company }}</p>
 
           <div class="mt-4 flex flex-wrap gap-2">
-            {% if job.remote_mode %}<span class="rounded-full bg-cyan-100 px-3 py-1 text-xs font-medium text-cyan-800">{{ job.remote_mode | capitalize }}</span>{% endif %}
-            {% if job.daily_salary %}<span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">{{ job.daily_salary }} / day</span>{% endif %}
-            {% if job.job_type %}<span class="rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800">{{ job.job_type }}</span>{% endif %}
+            {% if job.remote_mode %}<span class="rounded-full bg-cyan-400/15 px-3 py-1 text-xs font-medium text-cyan-200">{{ job.remote_mode | capitalize }}</span>{% endif %}
+            {% if job.daily_salary %}<span class="rounded-full bg-emerald-400/15 px-3 py-1 text-xs font-medium text-emerald-200">{{ job.daily_salary }} / day</span>{% endif %}
+            {% if job.job_type %}<span class="rounded-full bg-violet-400/15 px-3 py-1 text-xs font-medium text-violet-200">{{ job.job_type }}</span>{% endif %}
           </div>
 
-          <p class="mt-4 text-sm text-slate-600"><i class="fas fa-map-marker-alt mr-2"></i>{{ job.location }}</p>
+          <p class="mt-4 text-sm text-slate-400"><i class="fas fa-map-marker-alt mr-2"></i>{{ job.location }}</p>
         </div>
 
         <div class="flex flex-col gap-2 sm:flex-row md:flex-col">
-          <a href="{{ job.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-emerald-700">
+          <a href="{{ job.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400">
             <i class="fas fa-external-link-alt mr-2"></i> Apply
           </a>
-          <a href="/jobs/freework?page={{ return_page }}&per_page={{ per_page }}" class="inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+          <a href="/jobs/freework?page={{ return_page }}&per_page={{ per_page }}" class="inline-flex items-center justify-center rounded-xl border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-emerald-400/50 hover:text-emerald-300">
             <i class="fas fa-list mr-2"></i> All Jobs
           </a>
         </div>
       </div>
     </section>
 
-    <section class="mt-6 grid gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2">
+    <section class="mt-6 grid gap-4 rounded-2xl glass p-6 shadow-sm md:grid-cols-2">
       <div>
         <p class="text-xs uppercase tracking-wide text-slate-500">Published</p>
-        <p class="mt-1 text-sm font-medium text-slate-800">{{ job.published_at | relative_time }}</p>
+        <p class="mt-1 text-sm font-medium text-slate-200">{{ job.published_at | relative_time }}</p>
       </div>
       <div>
         <p class="text-xs uppercase tracking-wide text-slate-500">Remote Mode</p>
-        <p class="mt-1 text-sm font-medium text-slate-800">{{ job.remote_mode | capitalize }}</p>
+        <p class="mt-1 text-sm font-medium text-slate-200">{{ job.remote_mode | capitalize }}</p>
       </div>
       {% if job.daily_salary %}
       <div>
         <p class="text-xs uppercase tracking-wide text-slate-500">Daily Salary</p>
-        <p class="mt-1 text-sm font-semibold text-emerald-700">{{ job.daily_salary }}</p>
+        <p class="mt-1 text-sm font-semibold text-emerald-300">{{ job.daily_salary }}</p>
       </div>
       {% endif %}
       {% if job.job_type %}
       <div>
         <p class="text-xs uppercase tracking-wide text-slate-500">Job Type</p>
-        <p class="mt-1 text-sm font-medium text-slate-800">{{ job.job_type }}</p>
+        <p class="mt-1 text-sm font-medium text-slate-200">{{ job.job_type }}</p>
       </div>
       {% endif %}
     </section>
 
     {% if job.description %}
-    <section class="mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h2 class="font-display text-xl font-bold text-slate-900">Description</h2>
-      <div class="prose mt-4 max-w-none text-slate-700">{{ job.description | safe }}</div>
+    <section class="mt-6 rounded-2xl glass p-6 shadow-sm">
+      <h2 class="font-display text-xl font-bold text-white">Description</h2>
+      <div class="prose prose-invert mt-4 max-w-none text-slate-300">{{ job.description | safe }}</div>
     </section>
     {% endif %}
 
     {% if job.requirements %}
-    <section class="mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h2 class="font-display text-xl font-bold text-slate-900">Requirements</h2>
-      <div class="prose mt-4 max-w-none text-slate-700">{{ job.requirements | safe }}</div>
+    <section class="mt-6 rounded-2xl glass p-6 shadow-sm">
+      <h2 class="font-display text-xl font-bold text-white">Requirements</h2>
+      <div class="prose prose-invert mt-4 max-w-none text-slate-300">{{ job.requirements | safe }}</div>
     </section>
     {% endif %}
 
     {% if job.skills %}
-    <section class="mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h2 class="font-display text-xl font-bold text-slate-900">Skills</h2>
+    <section class="mt-6 rounded-2xl glass p-6 shadow-sm">
+      <h2 class="font-display text-xl font-bold text-white">Skills</h2>
       <div class="mt-4 flex flex-wrap gap-2">
         {% for skill in job.skills %}
-        <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">{{ skill }}</span>
+        <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-slate-300">{{ skill }}</span>
         {% endfor %}
       </div>
     </section>
     {% endif %}
 
     {% if similar_jobs %}
-    <section class="mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h2 class="font-display text-xl font-bold text-slate-900">Similar Jobs</h2>
+    <section class="mt-6 rounded-2xl glass p-6 shadow-sm">
+      <h2 class="font-display text-xl font-bold text-white">Similar Jobs</h2>
       <div class="mt-4 grid gap-4 md:grid-cols-2">
         {% for similar_job in similar_jobs %}
-        <a href="/jobs/freework/{{ similar_job.id }}?return_page={{ return_page }}&per_page={{ per_page }}" class="rounded-xl border border-slate-200 p-4 transition hover:-translate-y-0.5 hover:border-emerald-300 hover:bg-slate-50">
-          <p class="font-semibold text-slate-900">{{ similar_job.title }}</p>
-          <p class="mt-1 text-sm text-slate-600">{{ similar_job.company }}</p>
+        <a href="/jobs/freework/{{ similar_job.id }}?return_page={{ return_page }}&per_page={{ per_page }}" class="card-hover rounded-xl border border-white/10 bg-white/5 p-4">
+          <p class="font-semibold text-white">{{ similar_job.title }}</p>
+          <p class="mt-1 text-sm text-slate-400">{{ similar_job.company }}</p>
           <div class="mt-3 flex flex-wrap gap-2">
-            {% if similar_job.remote_mode %}<span class="rounded-full bg-cyan-100 px-2.5 py-1 text-xs font-medium text-cyan-800">{{ similar_job.remote_mode | capitalize }}</span>{% endif %}
-            {% if similar_job.daily_salary %}<span class="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-medium text-emerald-800">{{ similar_job.daily_salary }} / day</span>{% endif %}
+            {% if similar_job.remote_mode %}<span class="rounded-full bg-cyan-400/15 px-2.5 py-1 text-xs font-medium text-cyan-200">{{ similar_job.remote_mode | capitalize }}</span>{% endif %}
+            {% if similar_job.daily_salary %}<span class="rounded-full bg-emerald-400/15 px-2.5 py-1 text-xs font-medium text-emerald-200">{{ similar_job.daily_salary }} / day</span>{% endif %}
           </div>
           <p class="mt-3 text-xs text-slate-500">{{ similar_job.published_at | relative_time }}</p>
         </a>

--- a/templates/jobs/linkedin.html
+++ b/templates/jobs/linkedin.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>LinkedIn Job Listings | Hocine ABED</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
 
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -13,171 +14,220 @@
         extend: {
           fontFamily: {
             display: ['Sora', 'sans-serif'],
-            body: ['Plus Jakarta Sans', 'sans-serif']
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
           }
         }
       }
     }
   </script>
 
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-
-  <style>
-    body {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      background:
-        radial-gradient(circle at 15% 0%, rgba(14, 165, 233, 0.12), transparent 38%),
-        radial-gradient(circle at 90% 20%, rgba(249, 115, 22, 0.1), transparent 36%),
-        #f8fafc;
-    }
-  </style>
+  <link rel="stylesheet" href="/static/css/style.css" />
 </head>
 
-<body class="text-slate-800">
+<body>
   {% include "partials/navbar.html" %}
 
-  <main class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-    <header class="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-      <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700">LinkedIn Source</p>
-      <h1 class="mt-3 font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">LinkedIn Job Opportunities</h1>
-      <p class="mt-3 max-w-3xl text-sm leading-relaxed text-slate-600 sm:text-base">
-        Filter and browse scraped LinkedIn opportunities by country, continent, source, and posting date.
+  <main class="relative mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+    <div class="glow -left-20 top-0 h-64 w-64 bg-cyan-500/20"></div>
+
+    <header class="glass relative rounded-3xl p-8 shadow-sm">
+      <p class="font-code text-xs uppercase tracking-[0.2em] text-cyan-300">// linkedin source</p>
+      <h1 class="mt-3 font-display text-3xl font-extrabold text-white sm:text-4xl">LinkedIn Job Opportunities</h1>
+      <p class="mt-3 max-w-3xl text-sm leading-relaxed text-slate-300 sm:text-base">
+        Search by keyword, filter by country, continent, source, and date — then track which offers you want to apply to.
       </p>
 
       <div class="mt-6 flex flex-wrap gap-3">
-        <a href="/jobs/freework" class="inline-flex items-center rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-700">
+        <a href="/jobs/freework" class="inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:brightness-110">
           <i class="fas fa-briefcase mr-2"></i> View Freework Jobs
         </a>
-        <a href="https://github.com/housine35/linkedin-job-scraper" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-cyan-500 hover:text-cyan-700">
+        <a href="https://github.com/housine35/linkedin-job-scraper" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-xl border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-400/50 hover:text-cyan-300">
           <i class="fab fa-github mr-2"></i> LinkedIn Scraper Repo
         </a>
       </div>
     </header>
 
-    <section class="mt-8 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <form method="get" action="/jobs/linkedin" id="filter-form" class="grid gap-4 md:grid-cols-5">
-        <div>
-          <label for="country-filter" class="mb-2 block text-sm font-medium text-slate-700">Country</label>
-          <select id="country-filter" name="country" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-100">
-            <option value="all">All Countries</option>
-            {% for country in unique_countries %}
-            <option value="{{ country }}" {% if country==selected_country %}selected{% endif %}>{{ country }}</option>
-            {% endfor %}
-          </select>
+    <!-- Filters -->
+    <section class="mt-8 glass rounded-2xl p-6 shadow-sm">
+      <form method="get" action="/jobs/linkedin" id="filter-form">
+        <!-- Keyword search -->
+        <div class="mb-4">
+          <label for="q" class="mb-2 block text-sm font-medium text-slate-300">Keyword (job title or company)</label>
+          <div class="flex gap-2">
+            <div class="relative flex-1">
+              <i class="fas fa-search pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-500"></i>
+              <input type="search" id="q" name="q" value="{{ selected_q }}" placeholder="e.g. Python, data engineer, scraping…"
+                class="w-full rounded-xl border border-white/15 bg-white/5 py-2.5 pl-10 pr-3 text-sm text-slate-100 placeholder-slate-500 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/20" />
+            </div>
+            <button type="submit" class="inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:brightness-110">
+              Search
+            </button>
+            <a href="/jobs/linkedin" class="inline-flex items-center rounded-xl border border-white/15 bg-white/5 px-4 py-2.5 text-sm font-medium text-slate-300 transition hover:border-cyan-400/50 hover:text-cyan-300">
+              Reset
+            </a>
+          </div>
         </div>
 
-        <div>
-          <label for="continent-filter" class="mb-2 block text-sm font-medium text-slate-700">Continent</label>
-          <select id="continent-filter" name="continent" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-100">
-            <option value="all">All Continents</option>
-            {% for continent in unique_continents %}
-            <option value="{{ continent }}" {% if continent==selected_continent %}selected{% endif %}>{{ continent }}</option>
-            {% endfor %}
-          </select>
-        </div>
+        <label class="mb-4 inline-flex cursor-pointer items-center gap-2 text-sm text-slate-300">
+          <input type="checkbox" id="it-only" name="it_only" value="true" {% if selected_it_only %}checked{% endif %}
+            class="h-4 w-4 rounded border-white/20 bg-white/5 text-cyan-500 focus:ring-cyan-500/30" />
+          <span><i class="fas fa-microchip mr-1 text-cyan-300"></i>IT jobs only</span>
+          <span class="text-xs text-slate-500">(filters out non-tech roles)</span>
+        </label>
 
-        <div>
-          <label for="date-filter" class="mb-2 block text-sm font-medium text-slate-700">Date</label>
-          <select id="date-filter" name="date" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-100">
-            <option value="all">All Dates</option>
-            {% for date in unique_dates %}
-            <option value="{{ date }}" {% if date==selected_date %}selected{% endif %}>{{ date }}</option>
-            {% endfor %}
-          </select>
-        </div>
+        <div class="grid gap-4 md:grid-cols-5">
+          <div>
+            <label for="country-filter" class="mb-2 block text-sm font-medium text-slate-300">Country</label>
+            <select id="country-filter" name="country" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/20">
+              <option value="all" class="bg-slate-900">All Countries</option>
+              {% for country in unique_countries %}
+              <option value="{{ country }}" class="bg-slate-900" {% if country==selected_country %}selected{% endif %}>{{ country }}</option>
+              {% endfor %}
+            </select>
+          </div>
 
-        <div>
-          <label for="source-filter" class="mb-2 block text-sm font-medium text-slate-700">Source</label>
-          <select id="source-filter" name="source" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-100">
-            <option value="all">All Sources</option>
-            {% for source in unique_sources %}
-            <option value="{{ source }}" {% if source==selected_source %}selected{% endif %}>{{ source }}</option>
-            {% endfor %}
-          </select>
-        </div>
+          <div>
+            <label for="continent-filter" class="mb-2 block text-sm font-medium text-slate-300">Continent</label>
+            <select id="continent-filter" name="continent" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/20">
+              <option value="all" class="bg-slate-900">All Continents</option>
+              {% for continent in unique_continents %}
+              <option value="{{ continent }}" class="bg-slate-900" {% if continent==selected_continent %}selected{% endif %}>{{ continent }}</option>
+              {% endfor %}
+            </select>
+          </div>
 
-        <div>
-          <label for="per-page" class="mb-2 block text-sm font-medium text-slate-700">Per Page</label>
-          <select id="per-page" name="per_page" class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-100">
-            <option value="10" {% if per_page==10 %}selected{% endif %}>10</option>
-            <option value="20" {% if per_page==20 %}selected{% endif %}>20</option>
-            <option value="50" {% if per_page==50 %}selected{% endif %}>50</option>
-            <option value="100" {% if per_page==100 %}selected{% endif %}>100</option>
-          </select>
+          <div>
+            <label for="date-filter" class="mb-2 block text-sm font-medium text-slate-300">Date</label>
+            <select id="date-filter" name="date" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/20">
+              <option value="all" class="bg-slate-900">All Dates</option>
+              {% for date in unique_dates %}
+              <option value="{{ date }}" class="bg-slate-900" {% if date==selected_date %}selected{% endif %}>{{ date }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div>
+            <label for="source-filter" class="mb-2 block text-sm font-medium text-slate-300">Source</label>
+            <select id="source-filter" name="source" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/20">
+              <option value="all" class="bg-slate-900">All Sources</option>
+              {% for source in unique_sources %}
+              <option value="{{ source }}" class="bg-slate-900" {% if source==selected_source %}selected{% endif %}>{{ source }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div>
+            <label for="per-page" class="mb-2 block text-sm font-medium text-slate-300">Per Page</label>
+            <select id="per-page" name="per_page" class="w-full rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-slate-100 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/20">
+              <option value="10" class="bg-slate-900" {% if per_page==10 %}selected{% endif %}>10</option>
+              <option value="20" class="bg-slate-900" {% if per_page==20 %}selected{% endif %}>20</option>
+              <option value="50" class="bg-slate-900" {% if per_page==50 %}selected{% endif %}>50</option>
+              <option value="100" class="bg-slate-900" {% if per_page==100 %}selected{% endif %}>100</option>
+            </select>
+          </div>
         </div>
 
         <input type="hidden" name="page" value="{{ page }}" />
       </form>
     </section>
 
-    <section class="mt-6 flex items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm">
-      <p class="text-slate-700">
-        {% if selected_country != "all" or selected_continent != "all" or selected_date != "all" or selected_source != "all" %}
-        <span class="font-semibold text-cyan-700">{{ filtered_jobs_count }}</span> filtered jobs
+    <!-- Result count + tracking filter toolbar -->
+    <section class="mt-6 flex flex-col gap-4 rounded-2xl glass px-4 py-3 text-sm shadow-sm sm:flex-row sm:items-center sm:justify-between">
+      <p class="text-slate-300">
+        {% if selected_q or selected_it_only or selected_country != "all" or selected_continent != "all" or selected_date != "all" or selected_source != "all" %}
+        <span class="font-semibold text-cyan-300">{{ filtered_jobs_count }}</span> matching jobs
         {% else %}
-        Showing <span class="font-semibold text-cyan-700">{{ filtered_jobs_count }}</span> jobs
+        Showing <span class="font-semibold text-cyan-300">{{ filtered_jobs_count }}</span> jobs
         {% endif %}
         <span class="text-slate-500">(out of {{ total_jobs }} total)</span>
+        {% if selected_q %}<span class="ml-1 text-slate-400">for “<span class="text-slate-200">{{ selected_q }}</span>”</span>{% endif %}
       </p>
+
+      <div class="flex flex-wrap items-center gap-2" id="track-toolbar">
+        <button type="button" data-track-filter="all" class="track-tab rounded-lg border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 text-xs font-semibold text-cyan-200">All</button>
+        <button type="button" data-track-filter="fav" class="track-tab rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-300 hover:text-amber-300">
+          <i class="fas fa-star mr-1 text-amber-400"></i>Favorites <span data-count="fav">0</span>
+        </button>
+        <button type="button" data-track-filter="applied" class="track-tab rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-300 hover:text-emerald-300">
+          <i class="fas fa-check mr-1 text-emerald-400"></i>Applied <span data-count="applied">0</span>
+        </button>
+        <button type="button" data-track-filter="hide-applied" class="track-tab rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-300 hover:text-slate-100">
+          Hide applied
+        </button>
+      </div>
     </section>
 
-    <section class="mt-6 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <!-- Jobs table -->
+    <section class="mt-6 overflow-hidden rounded-2xl glass shadow-sm">
       {% if jobs|length > 0 %}
       <div class="overflow-x-auto">
         <table class="min-w-full text-sm">
-          <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+          <thead class="bg-white/5 text-xs uppercase tracking-wide text-slate-400">
             <tr>
               <th class="px-5 py-4 text-left">Job</th>
               <th class="px-5 py-4 text-left">Company</th>
               <th class="px-5 py-4 text-left">Location</th>
               <th class="px-5 py-4 text-left">Source</th>
               <th class="px-5 py-4 text-left">Published</th>
-              <th class="px-5 py-4 text-right">Action</th>
+              <th class="px-5 py-4 text-right">Track / Action</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-slate-200">
+          <tbody class="divide-y divide-white/5" id="jobs-body">
             {% for job in jobs %}
-            <tr class="transition hover:bg-slate-50">
+            <tr class="job-row transition hover:bg-white/5" data-url="{{ job.url }}">
               <td class="px-5 py-4">
-                <p class="font-semibold text-slate-900">{{ job.title }}</p>
+                <p class="font-semibold text-white">{{ job.title }}</p>
                 <div class="mt-2 flex flex-wrap gap-2">
-                  {% if job.country %}<span class="rounded-full bg-cyan-100 px-2.5 py-1 text-xs font-medium text-cyan-800">{{ job.country }}</span>{% endif %}
-                  {% if job.continent %}<span class="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">{{ job.continent }}</span>{% endif %}
+                  {% if job.country %}<span class="rounded-full bg-cyan-400/15 px-2.5 py-1 text-xs font-medium text-cyan-200">{{ job.country }}</span>{% endif %}
+                  {% if job.continent %}<span class="rounded-full bg-white/5 px-2.5 py-1 text-xs font-medium text-slate-300">{{ job.continent }}</span>{% endif %}
                 </div>
               </td>
-              <td class="px-5 py-4 font-medium text-slate-800">{{ job.company }}</td>
-              <td class="px-5 py-4 text-slate-600">{{ job.location }}</td>
-              <td class="px-5 py-4 text-slate-600">{{ job.source | default('Unknown') }}</td>
+              <td class="px-5 py-4 font-medium text-slate-200">{{ job.company }}</td>
+              <td class="px-5 py-4 text-slate-400">{{ job.location }}</td>
+              <td class="px-5 py-4 text-slate-400">{{ job.source | default('Unknown') }}</td>
               <td class="px-5 py-4 text-slate-500">{{ job.posting_time | relative_time }}</td>
-              <td class="px-5 py-4 text-right">
-                <a href="{{ job.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-lg bg-cyan-600 px-4 py-2 text-xs font-semibold text-white transition hover:bg-cyan-700">
-                  <i class="fas fa-eye mr-2"></i> View
-                </a>
+              <td class="px-5 py-4">
+                <div class="flex items-center justify-end gap-2">
+                  <button type="button" class="btn-fav inline-flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition hover:text-amber-300" title="Mark as favorite" aria-pressed="false">
+                    <i class="fa-star fa-regular"></i>
+                  </button>
+                  <button type="button" class="btn-applied inline-flex h-8 items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2.5 text-xs font-medium text-slate-400 transition hover:text-emerald-300" title="Mark as applied" aria-pressed="false">
+                    <i class="fas fa-check"></i><span class="applied-label">Applied</span>
+                  </button>
+                  <a href="{{ job.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-lg bg-gradient-to-r from-cyan-400 to-blue-600 px-3 py-2 text-xs font-semibold text-slate-950 transition hover:brightness-110">
+                    <i class="fas fa-arrow-up-right-from-square mr-1.5"></i> View
+                  </a>
+                </div>
               </td>
             </tr>
             {% endfor %}
           </tbody>
         </table>
       </div>
+      <div id="no-track-match" class="hidden px-6 py-12 text-center text-slate-400">
+        <p class="text-sm">No jobs on this page match that tracking filter.</p>
+      </div>
       {% else %}
-      <div class="px-6 py-16 text-center text-slate-500">
-        <p class="text-lg font-semibold text-slate-700">No jobs found</p>
-        <p class="mt-1 text-sm">Try adjusting your filters.</p>
+      <div class="px-6 py-16 text-center text-slate-400">
+        <p class="text-lg font-semibold text-slate-200">No jobs found</p>
+        <p class="mt-1 text-sm">Try a different keyword or adjust your filters.</p>
       </div>
       {% endif %}
     </section>
 
     {% if jobs|length > 0 %}
-    <section class="mt-6 flex flex-col justify-between gap-4 rounded-2xl border border-slate-200 bg-white p-4 text-sm shadow-sm sm:flex-row sm:items-center">
-      <p class="text-slate-600">
-        Showing <span class="font-semibold">{{ ((page - 1) * per_page) + 1 }}</span> to
-        <span class="font-semibold">{{ [page * per_page, filtered_jobs_count]|min }}</span> of
-        <span class="font-semibold">{{ filtered_jobs_count }}</span> results
+    <section class="mt-6 flex flex-col justify-between gap-4 rounded-2xl glass p-4 text-sm shadow-sm sm:flex-row sm:items-center">
+      <p class="text-slate-400">
+        Showing <span class="font-semibold text-slate-200">{{ ((page - 1) * per_page) + 1 }}</span> to
+        <span class="font-semibold text-slate-200">{{ [page * per_page, filtered_jobs_count]|min }}</span> of
+        <span class="font-semibold text-slate-200">{{ filtered_jobs_count }}</span> results
       </p>
       <div class="flex gap-2">
-        <a href="?country={{ selected_country }}&continent={{ selected_continent }}&date={{ selected_date }}&source={{ selected_source }}&page={{ page - 1 if page > 1 else 1 }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page <= 1 %}cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400{% else %}border-slate-300 bg-white text-slate-700 hover:bg-slate-50{% endif %}">Previous</a>
-        <a href="?country={{ selected_country }}&continent={{ selected_continent }}&date={{ selected_date }}&source={{ selected_source }}&page={{ page + 1 if page < total_pages else total_pages }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page >= total_pages %}cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400{% else %}border-slate-300 bg-white text-slate-700 hover:bg-slate-50{% endif %}">Next</a>
+        <a href="?q={{ selected_q | urlencode }}&country={{ selected_country }}&continent={{ selected_continent }}&date={{ selected_date }}&source={{ selected_source }}&it_only={{ 'true' if selected_it_only else '' }}&page={{ page - 1 if page > 1 else 1 }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page <= 1 %}cursor-not-allowed border-white/5 bg-white/5 text-slate-600{% else %}border-white/15 bg-white/5 text-slate-200 hover:border-cyan-400/50 hover:text-cyan-300{% endif %}">Previous</a>
+        <a href="?q={{ selected_q | urlencode }}&country={{ selected_country }}&continent={{ selected_continent }}&date={{ selected_date }}&source={{ selected_source }}&it_only={{ 'true' if selected_it_only else '' }}&page={{ page + 1 if page < total_pages else total_pages }}&per_page={{ per_page }}" class="rounded-lg border px-4 py-2 {% if page >= total_pages %}cursor-not-allowed border-white/5 bg-white/5 text-slate-600{% else %}border-white/15 bg-white/5 text-slate-200 hover:border-cyan-400/50 hover:text-cyan-300{% endif %}">Next</a>
       </div>
     </section>
     {% endif %}
@@ -186,26 +236,123 @@
   {% include "partials/footer.html" %}
 
   <script>
-    const debounce = (fn, delay) => {
-      let timeout;
-      return (...args) => {
-        clearTimeout(timeout);
-        timeout = setTimeout(() => fn(...args), delay);
-      };
-    };
+    /* ---- Auto-submit filters (dropdowns) ---- */
+    (function () {
+      const form = document.getElementById('filter-form');
+      if (!form) return;
+      const debounce = (fn, d) => { let t; return (...a) => { clearTimeout(t); t = setTimeout(() => fn(...a), d); }; };
+      const submit = debounce(() => form.submit(), 250);
+      ['country-filter', 'continent-filter', 'date-filter', 'source-filter'].forEach(id => {
+        document.getElementById(id)?.addEventListener('change', submit);
+      });
+      document.getElementById('per-page')?.addEventListener('change', () => {
+        form.querySelector('input[name="page"]').value = 1;
+        submit();
+      });
+      document.getElementById('it-only')?.addEventListener('change', () => {
+        form.querySelector('input[name="page"]').value = 1;
+        submit();
+      });
+      // Submit keyword search on Enter (handled natively) or after typing pause.
+      const q = document.getElementById('q');
+      const qSubmit = debounce(() => { form.querySelector('input[name="page"]').value = 1; form.submit(); }, 700);
+      q?.addEventListener('input', qSubmit);
+    })();
 
-    const submitForm = debounce(() => {
-      document.getElementById('filter-form').submit();
-    }, 300);
+    /* ---- Application tracking (localStorage, per job URL) ---- */
+    (function () {
+      const KEY = 'linkedin_job_status';
+      const load = () => { try { return JSON.parse(localStorage.getItem(KEY)) || {}; } catch { return {}; } };
+      const save = (s) => localStorage.setItem(KEY, JSON.stringify(s));
+      let store = load();
+      let activeFilter = 'all';
 
-    document.getElementById('country-filter')?.addEventListener('change', submitForm);
-    document.getElementById('continent-filter')?.addEventListener('change', submitForm);
-    document.getElementById('date-filter')?.addEventListener('change', submitForm);
-    document.getElementById('source-filter')?.addEventListener('change', submitForm);
-    document.getElementById('per-page')?.addEventListener('change', () => {
-      document.querySelector('input[name="page"]').value = 1;
-      submitForm();
-    });
+      const rows = Array.from(document.querySelectorAll('.job-row'));
+      const noMatch = document.getElementById('no-track-match');
+
+      function paintRow(row) {
+        const url = row.dataset.url;
+        const st = store[url] || {};
+        const favBtn = row.querySelector('.btn-fav');
+        const favIcon = favBtn.querySelector('i');
+        const appliedBtn = row.querySelector('.btn-applied');
+
+        if (st.fav) {
+          favIcon.className = 'fa-star fa-solid text-amber-400';
+          favBtn.classList.add('border-amber-400/40', 'text-amber-300');
+          favBtn.setAttribute('aria-pressed', 'true');
+        } else {
+          favIcon.className = 'fa-star fa-regular';
+          favBtn.classList.remove('border-amber-400/40', 'text-amber-300');
+          favBtn.setAttribute('aria-pressed', 'false');
+        }
+
+        if (st.applied) {
+          appliedBtn.classList.add('border-emerald-400/40', 'text-emerald-300', 'bg-emerald-400/10');
+          appliedBtn.setAttribute('aria-pressed', 'true');
+          row.classList.add('opacity-50');
+        } else {
+          appliedBtn.classList.remove('border-emerald-400/40', 'text-emerald-300', 'bg-emerald-400/10');
+          appliedBtn.setAttribute('aria-pressed', 'false');
+          row.classList.remove('opacity-50');
+        }
+      }
+
+      function updateCounts() {
+        const vals = Object.values(store);
+        document.querySelector('[data-count="fav"]').textContent = vals.filter(v => v.fav).length;
+        document.querySelector('[data-count="applied"]').textContent = vals.filter(v => v.applied).length;
+      }
+
+      function applyFilter() {
+        let visible = 0;
+        rows.forEach(row => {
+          const st = store[row.dataset.url] || {};
+          let show = true;
+          if (activeFilter === 'fav') show = !!st.fav;
+          else if (activeFilter === 'applied') show = !!st.applied;
+          else if (activeFilter === 'hide-applied') show = !st.applied;
+          row.classList.toggle('hidden', !show);
+          if (show) visible++;
+        });
+        if (noMatch) noMatch.classList.toggle('hidden', visible !== 0);
+      }
+
+      // Wire row buttons
+      rows.forEach(row => {
+        const url = row.dataset.url;
+        row.querySelector('.btn-fav').addEventListener('click', () => {
+          store[url] = store[url] || {};
+          store[url].fav = !store[url].fav;
+          save(store); paintRow(row); updateCounts(); applyFilter();
+        });
+        row.querySelector('.btn-applied').addEventListener('click', () => {
+          store[url] = store[url] || {};
+          store[url].applied = !store[url].applied;
+          save(store); paintRow(row); updateCounts(); applyFilter();
+        });
+        paintRow(row);
+      });
+
+      // Wire toolbar tabs
+      document.querySelectorAll('.track-tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+          activeFilter = tab.dataset.trackFilter;
+          document.querySelectorAll('.track-tab').forEach(t => {
+            const on = t === tab;
+            t.classList.toggle('border-cyan-400/50', on);
+            t.classList.toggle('bg-cyan-400/10', on);
+            t.classList.toggle('text-cyan-200', on);
+            t.classList.toggle('border-white/10', !on);
+            t.classList.toggle('bg-white/5', !on);
+            t.classList.toggle('text-slate-300', !on);
+          });
+          applyFilter();
+        });
+      });
+
+      updateCounts();
+    })();
   </script>
 </body>
 

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -6,7 +6,7 @@
     <div>
       <p class="text-lg font-semibold text-white">Hocine ABED</p>
       <p class="mt-2 text-sm leading-relaxed text-slate-300">
-        Web scraping engineer focused on extracting clean, usable data from complex websites and turning it into reliable products.
+        Web scraping &amp; reverse-engineering engineer focused on extracting clean, usable data from protected, complex sources and turning it into reliable products.
       </p>
     </div>
 

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -1,52 +1,52 @@
-<nav class="sticky top-0 z-50 border-b border-white/40 bg-white/80 backdrop-blur-xl">
+<nav class="sticky top-0 z-50 border-b border-white/10 bg-slate-950/70 backdrop-blur-xl">
   <div class="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
     <a href="/index" class="group inline-flex items-center gap-3">
-      <span class="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-500 to-blue-700 text-white shadow-sm transition-transform duration-300 group-hover:rotate-6 group-hover:scale-105">
+      <span class="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-400 to-blue-600 text-slate-950 shadow-sm shadow-cyan-500/30 transition-transform duration-300 group-hover:rotate-6 group-hover:scale-105">
         <i class="fas fa-spider text-sm"></i>
       </span>
-      <span class="text-base font-semibold tracking-tight text-slate-900 sm:text-lg">Hocine ABED</span>
+      <span class="text-base font-semibold tracking-tight text-white sm:text-lg">Hocine ABED</span>
     </a>
 
     <div class="hidden items-center gap-1 md:flex">
-      <a href="/index" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-cyan-50 hover:text-cyan-700">Home</a>
-      <a href="/projects" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-cyan-50 hover:text-cyan-700">Projects</a>
-      <a href="/resume" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-cyan-50 hover:text-cyan-700">Resume</a>
+      <a href="/index" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 hover:text-cyan-300">Home</a>
+      <a href="/projects" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 hover:text-cyan-300">Projects</a>
+      <a href="/resume" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 hover:text-cyan-300">Resume</a>
       <div class="group relative">
-        <button type="button" class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-cyan-50 hover:text-cyan-700">
+        <button type="button" class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 hover:text-cyan-300">
           Social Media
           <i class="fas fa-chevron-down ml-2 text-xs"></i>
         </button>
-        <div class="invisible absolute left-0 top-full z-20 mt-1 w-52 rounded-xl border border-slate-200 bg-white p-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100">
-          <a href="https://facebook-scraper-q8aa.onrender.com/" target="_blank" rel="noopener noreferrer" class="flex items-center rounded-lg px-3 py-2 text-sm text-slate-700 transition hover:bg-blue-50 hover:text-blue-700">
+        <div class="invisible absolute left-0 top-full z-20 mt-1 w-52 rounded-xl border border-white/10 bg-slate-900/95 p-1 opacity-0 shadow-lg backdrop-blur-xl transition-all group-hover:visible group-hover:opacity-100">
+          <a href="https://facebook-scraper-q8aa.onrender.com/" target="_blank" rel="noopener noreferrer" class="flex items-center rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-white/5 hover:text-cyan-300">
             <i class="fab fa-facebook mr-2"></i> Facebook Scraper
           </a>
-          <a href="https://tiktok-scraper-yt8p.onrender.com/" target="_blank" rel="noopener noreferrer" class="flex items-center rounded-lg px-3 py-2 text-sm text-slate-700 transition hover:bg-pink-50 hover:text-pink-700">
+          <a href="https://tiktok-scraper-yt8p.onrender.com/" target="_blank" rel="noopener noreferrer" class="flex items-center rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-white/5 hover:text-pink-300">
             <i class="fab fa-tiktok mr-2"></i> TikTok Scraper
           </a>
         </div>
       </div>
-      <a href="/jobs/linkedin" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-cyan-50 hover:text-cyan-700">LinkedIn Jobs</a>
-      <a href="/jobs/freework" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-cyan-50 hover:text-cyan-700">Freework Jobs</a>
-      <a href="/contact" class="ml-2 inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700">Contact</a>
+      <a href="/jobs/linkedin" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 hover:text-cyan-300">LinkedIn Jobs</a>
+      <a href="/jobs/freework" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 hover:text-cyan-300">Freework Jobs</a>
+      <a href="/contact" class="ml-2 inline-flex items-center rounded-lg bg-gradient-to-r from-cyan-400 to-blue-600 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:brightness-110">Contact</a>
     </div>
 
-    <button id="mobile-menu-toggle" type="button" class="inline-flex items-center justify-center rounded-lg p-2 text-slate-700 transition hover:bg-slate-100 md:hidden" aria-controls="mobile-menu" aria-expanded="false">
+    <button id="mobile-menu-toggle" type="button" class="inline-flex items-center justify-center rounded-lg p-2 text-slate-200 transition hover:bg-white/10 md:hidden" aria-controls="mobile-menu" aria-expanded="false">
       <span class="sr-only">Open menu</span>
       <i class="fas fa-bars"></i>
     </button>
   </div>
 
-  <div id="mobile-menu" class="hidden border-t border-slate-200/70 bg-white/95 px-4 py-3 md:hidden">
+  <div id="mobile-menu" class="hidden border-t border-white/10 bg-slate-950/95 px-4 py-3 backdrop-blur-xl md:hidden">
     <div class="flex flex-col gap-1">
-      <a href="/index" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-cyan-50">Home</a>
-      <a href="/projects" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-cyan-50">Projects</a>
-      <a href="/resume" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-cyan-50">Resume</a>
-      <p class="px-3 pt-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Social Media</p>
-      <a href="https://facebook-scraper-q8aa.onrender.com/" target="_blank" rel="noopener noreferrer" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-cyan-50">Facebook Scraper</a>
-      <a href="https://tiktok-scraper-yt8p.onrender.com/" target="_blank" rel="noopener noreferrer" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-cyan-50">TikTok Scraper</a>
-      <a href="/jobs/linkedin" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-cyan-50">LinkedIn Jobs</a>
-      <a href="/jobs/freework" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-cyan-50">Freework Jobs</a>
-      <a href="/contact" class="mt-1 rounded-lg bg-slate-900 px-3 py-2 text-center text-sm font-medium text-white">Contact</a>
+      <a href="/index" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:bg-white/5 hover:text-cyan-300">Home</a>
+      <a href="/projects" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:bg-white/5 hover:text-cyan-300">Projects</a>
+      <a href="/resume" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:bg-white/5 hover:text-cyan-300">Resume</a>
+      <p class="px-3 pt-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Social Media</p>
+      <a href="https://facebook-scraper-q8aa.onrender.com/" target="_blank" rel="noopener noreferrer" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:bg-white/5 hover:text-cyan-300">Facebook Scraper</a>
+      <a href="https://tiktok-scraper-yt8p.onrender.com/" target="_blank" rel="noopener noreferrer" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:bg-white/5 hover:text-cyan-300">TikTok Scraper</a>
+      <a href="/jobs/linkedin" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:bg-white/5 hover:text-cyan-300">LinkedIn Jobs</a>
+      <a href="/jobs/freework" class="rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:bg-white/5 hover:text-cyan-300">Freework Jobs</a>
+      <a href="/contact" class="mt-1 rounded-lg bg-gradient-to-r from-cyan-400 to-blue-600 px-3 py-2 text-center text-sm font-semibold text-slate-950">Contact</a>
     </div>
   </div>
 </nav>

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -4,7 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Projects | Hocine ABED</title>
+  <title>Projects | Hocine ABED — Scraping & Reverse Engineering</title>
+  <meta name="description" content="Selected web scraping and reverse-engineering projects: social media extraction, jobs ETL pipelines, API analysis, and public data normalization." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
 
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -13,132 +15,67 @@
         extend: {
           fontFamily: {
             display: ['Sora', 'sans-serif'],
-            body: ['Plus Jakarta Sans', 'sans-serif']
-          },
-          keyframes: {
-            reveal: {
-              '0%': { opacity: 0, transform: 'translateY(16px)' },
-              '100%': { opacity: 1, transform: 'translateY(0)' }
-            }
-          },
-          animation: {
-            reveal: 'reveal .65s ease forwards'
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
           }
         }
       }
     }
   </script>
 
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-
-  <style>
-    body {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      background:
-        radial-gradient(circle at 20% 0%, rgba(14, 165, 233, 0.12), transparent 40%),
-        radial-gradient(circle at 100% 20%, rgba(249, 115, 22, 0.1), transparent 35%),
-        #f8fafc;
-    }
-
-    .fade-step {
-      animation: reveal .65s ease forwards;
-    }
-  </style>
+  <link rel="stylesheet" href="/static/css/style.css" />
 </head>
 
-<body class="text-slate-800">
+<body>
   {% include "partials/navbar.html" %}
 
-  <section class="border-b border-slate-200 bg-white/80">
-    <div class="mx-auto max-w-7xl px-6 py-16 sm:py-20">
-      <p class="fade-step text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700" style="animation-delay:.05s">Selected Work</p>
-      <h1 class="fade-step mt-4 max-w-3xl font-display text-4xl font-extrabold leading-tight text-slate-900 sm:text-5xl" style="animation-delay:.15s">Scraping projects built for speed, resilience, and clean output.</h1>
-      <p class="fade-step mt-5 max-w-2xl text-slate-600" style="animation-delay:.3s">From jobs platforms to social networks, each project is designed to survive layout changes and deliver consistent structured data.</p>
+  <section class="relative overflow-hidden border-b border-white/10">
+    <div class="tech-grid tech-grid--masked absolute inset-0 opacity-50"></div>
+    <div class="glow -left-20 top-0 h-64 w-64 bg-cyan-500/20"></div>
+    <div class="relative mx-auto max-w-7xl px-6 py-16 sm:py-20">
+      <p class="fade-step font-code text-xs uppercase tracking-[0.2em] text-cyan-300" style="animation-delay:.05s">// selected work</p>
+      <h1 class="fade-step mt-4 max-w-3xl font-display text-4xl font-extrabold leading-tight text-white sm:text-5xl" style="animation-delay:.15s">Scraping &amp; reverse-engineering projects built to survive.</h1>
+      <p class="fade-step mt-5 max-w-2xl text-slate-300" style="animation-delay:.3s">From social platforms to jobs boards, each system is designed to defeat anti-bot defenses, absorb layout changes, and deliver consistent structured data.</p>
     </div>
   </section>
 
   <main class="mx-auto max-w-7xl px-6 py-14">
-    {% set projects = [
-      {
-        "title": "LinkedIn Job Scraper",
-        "desc": "Extracts tech jobs with filters by source, country, and date, then serves them through a searchable interface.",
-        "tech": ["Python", "Playwright", "FastAPI", "MongoDB"],
-        "icon": "fab fa-linkedin-in",
-        "color": "cyan",
-        "url": "/jobs/linkedin",
-        "date": "2025-06-15"
-      },
-      {
-        "title": "Freework Freelance Scraper",
-        "desc": "Collects freelance opportunities, remote modes, and daily rates for real-time job exploration.",
-        "tech": ["Scrapy", "FastAPI", "ETL"],
-        "icon": "fas fa-briefcase",
-        "color": "emerald",
-        "url": "/jobs/freework",
-        "date": "2025-07-01"
-      },
-      {
-        "title": "Facebook Data Extractor",
-        "desc": "Captures post details and comments using authenticated browser automation and robust parsers.",
-        "tech": ["Playwright", "Reverse Engineering", "API Analysis"],
-        "icon": "fab fa-facebook-f",
-        "color": "blue",
-        "url": "https://facebook-scraper-q8aa.onrender.com/",
-        "date": "2025-01-10"
-      },
-      {
-        "title": "TikTok Extraction Engine",
-        "desc": "Retrieves post metadata and user graph data with anti-rate-limit handling and custom request signatures.",
-        "tech": ["Automation", "Signature Logic", "Data Pipelines"],
-        "icon": "fab fa-tiktok",
-        "color": "amber",
-        "url": "https://tiktok-scraper-yt8p.onrender.com/",
-        "date": "2025-04-22"
-      },
-      {
-        "title": "French Assembly and Senate Data",
-        "desc": "Scrapes legislative records including bills, votes, and profiles from parliamentary sources.",
-        "tech": ["Public Data", "Parsing", "Normalization"],
-        "icon": "fas fa-landmark",
-        "color": "violet",
-        "url": "/projects/gov",
-        "date": "2024-03-12"
-      },
-      {
-        "title": "Live Subtitle Capture",
-        "desc": "Captures live subtitles from video streams with OCR and near real-time text processing.",
-        "tech": ["OCR", "Streaming", "Speech Processing"],
-        "icon": "fas fa-video",
-        "color": "rose",
-        "url": "https://github.com/housine35/Aws_Puppeteer",
-        "date": "2025-02-18"
-      }
-    ] %}
-
     <section class="grid gap-6 md:grid-cols-2">
       {% for project in projects %}
-      <article class="fade-step group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md" style="animation-delay: {{ 0.05 + (loop.index0 * 0.06) }}s;">
+      <article class="fade-step glass card-hover group rounded-2xl p-6" style="animation-delay: {{ 0.05 + (loop.index0 * 0.06) }}s;">
         <div class="flex items-start justify-between gap-4">
-          <div class="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-{{ project.color }}-100 text-{{ project.color }}-700">
+          <div class="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-{{ project.color }}-400/15 text-{{ project.color }}-300">
             <i class="{{ project.icon }}"></i>
           </div>
-          <p class="text-xs font-medium text-slate-500">Updated {{ project.date }}</p>
+          <p class="font-code text-xs text-slate-500">Updated {{ project.date }}</p>
         </div>
 
-        <h2 class="mt-4 font-display text-xl font-bold text-slate-900">{{ project.title }}</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-600">{{ project.desc }}</p>
+        <h2 class="mt-4 font-display text-xl font-bold text-white">{{ project.title }}</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-400">{{ project.desc }}</p>
 
         <div class="mt-4 flex flex-wrap gap-2">
           {% for tech in project.tech %}
-          <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">{{ tech }}</span>
+          <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-slate-300">{{ tech }}</span>
           {% endfor %}
         </div>
 
-        <a href="{{ project.url }}" class="mt-6 inline-flex items-center text-sm font-semibold text-cyan-700 transition hover:text-cyan-900">
-          View Project
-          <i class="fas fa-arrow-right ml-2 text-xs"></i>
-        </a>
+        <div class="mt-6 flex flex-wrap items-center gap-4">
+          <a href="/projects/{{ project.slug }}" class="inline-flex items-center text-sm font-semibold text-{{ project.color }}-300 transition hover:text-{{ project.color }}-200">
+            Read case study
+            <i class="fas fa-arrow-right ml-2 text-xs"></i>
+          </a>
+          {% if project.url and project.url.startswith('http') %}
+          <a href="{{ project.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-sm font-medium text-slate-400 transition hover:text-slate-200">
+            <i class="fas fa-arrow-up-right-from-square mr-1.5 text-xs"></i> Live
+          </a>
+          {% elif project.url %}
+          <a href="{{ project.url }}" class="inline-flex items-center text-sm font-medium text-slate-400 transition hover:text-slate-200">
+            <i class="fas fa-table-list mr-1.5 text-xs"></i> Explore data
+          </a>
+          {% endif %}
+        </div>
       </article>
       {% endfor %}
     </section>

--- a/templates/projects_detail.html
+++ b/templates/projects_detail.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{ project.title }} | Case Study — Hocine ABED</title>
+  <meta name="description" content="{{ project.tagline }}" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            display: ['Sora', 'sans-serif'],
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
+          }
+        }
+      }
+    }
+  </script>
+
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="/static/css/style.css" />
+</head>
+
+<body>
+  {% include "partials/navbar.html" %}
+
+  <main class="relative mx-auto max-w-4xl px-6 py-12">
+    <div class="glow -left-20 top-0 h-64 w-64 bg-{{ project.color }}-500/20"></div>
+
+    <div class="mb-6">
+      <a href="/projects" class="inline-flex items-center text-sm font-medium text-slate-400 transition hover:text-cyan-300">
+        <i class="fas fa-arrow-left mr-2"></i> All projects
+      </a>
+    </div>
+
+    <!-- Header -->
+    <header class="glass relative rounded-3xl p-8 shadow-sm">
+      <div class="flex items-start gap-5">
+        <div class="inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-{{ project.color }}-400/15 text-2xl text-{{ project.color }}-300">
+          <i class="{{ project.icon }}"></i>
+        </div>
+        <div>
+          <p class="font-code text-xs uppercase tracking-[0.2em] text-{{ project.color }}-300">// case study</p>
+          <h1 class="mt-2 font-display text-3xl font-extrabold text-white sm:text-4xl">{{ project.title }}</h1>
+          <p class="mt-2 text-lg text-slate-300">{{ project.tagline }}</p>
+        </div>
+      </div>
+
+      <div class="mt-6 flex flex-wrap gap-2">
+        {% for tech in project.tech %}
+        <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-slate-300">{{ tech }}</span>
+        {% endfor %}
+      </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        {% if project.url and project.url.startswith('http') %}
+        <a href="{{ project.url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:brightness-110">
+          <i class="fas fa-arrow-up-right-from-square mr-2"></i> Live demo
+        </a>
+        {% elif project.url %}
+        <a href="{{ project.url }}" class="inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:brightness-110">
+          <i class="fas fa-table-list mr-2"></i> Explore data
+        </a>
+        {% endif %}
+        {% if project.repo %}
+        <a href="{{ project.repo }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-xl border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:border-cyan-400/50 hover:text-cyan-300">
+          <i class="fab fa-github mr-2"></i> Source
+        </a>
+        {% endif %}
+      </div>
+    </header>
+
+    <!-- Problem -->
+    <section class="mt-6 glass rounded-2xl p-7 shadow-sm">
+      <h2 class="font-code text-xs uppercase tracking-[0.2em] text-slate-500">// the problem</h2>
+      <p class="mt-3 leading-relaxed text-slate-300">{{ project.problem }}</p>
+    </section>
+
+    <!-- Approach -->
+    <section class="mt-6 glass rounded-2xl p-7 shadow-sm">
+      <h2 class="font-code text-xs uppercase tracking-[0.2em] text-slate-500">// the approach</h2>
+      <ul class="mt-4 space-y-3">
+        {% for step in project.approach %}
+        <li class="flex gap-3 text-slate-300">
+          <span class="mt-1 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-{{ project.color }}-400/15 text-[11px] font-bold text-{{ project.color }}-300">{{ loop.index }}</span>
+          <span class="leading-relaxed">{{ step }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    </section>
+
+    <!-- Results -->
+    <section class="mt-6 glass rounded-2xl p-7 shadow-sm">
+      <h2 class="font-code text-xs uppercase tracking-[0.2em] text-slate-500">// outcome</h2>
+      <div class="mt-4 grid gap-3 sm:grid-cols-2">
+        {% for r in project.results %}
+        <div class="flex items-start gap-3 rounded-xl border border-white/10 bg-white/5 p-4">
+          <i class="fas fa-circle-check mt-0.5 text-{{ project.color }}-300"></i>
+          <span class="text-sm text-slate-300">{{ r }}</span>
+        </div>
+        {% endfor %}
+      </div>
+    </section>
+
+    <!-- Other projects -->
+    {% if others %}
+    <section class="mt-10">
+      <h2 class="font-display text-lg font-bold text-white">More projects</h2>
+      <div class="mt-4 grid gap-4 sm:grid-cols-3">
+        {% for o in others %}
+        <a href="/projects/{{ o.slug }}" class="card-hover rounded-xl border border-white/10 bg-white/5 p-4">
+          <div class="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-{{ o.color }}-400/15 text-{{ o.color }}-300">
+            <i class="{{ o.icon }}"></i>
+          </div>
+          <p class="mt-3 font-semibold text-white">{{ o.title }}</p>
+          <p class="mt-1 text-xs text-slate-400 line-clamp-2">{{ o.tagline }}</p>
+        </a>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+  </main>
+
+  {% include "partials/footer.html" %}
+</body>
+
+</html>

--- a/templates/resume.html
+++ b/templates/resume.html
@@ -4,149 +4,80 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CV | Hocine ABED - Web Scraping & Backend Development Expert</title>
+  <title>CV | Hocine ABED — Web Scraping & Anti-Bot Engineer</title>
+  <meta name="description" content="Resume of Hocine ABED — Senior Web Scraping & Anti-Bot Engineer: high-volume crawlers, Cloudflare/DataDome/Akamai bypass, JS reverse engineering, FastAPI, Kubernetes." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕷️</text></svg>" />
+
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
-  <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
-    rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet">
 
   <script>
     tailwind.config = {
       theme: {
-        fontFamily: {
-          'sans': ['Inter', 'sans-serif'],
-          'heading': ['Space Grotesk', 'sans-serif'],
-        },
         extend: {
-          colors: {
-            primary: {
-              50: '#f0f9ff',
-              100: '#e0f2fe',
-              200: '#bae6fd',
-              300: '#7dd3fc',
-              400: '#38bdf8',
-              500: '#0ea5e9',
-              600: '#0284c7',
-              700: '#0369a1',
-              800: '#075985',
-              900: '#0c4a6e',
-            },
-            slate: {
-              50: '#f8fafc',
-              100: '#f1f5f9',
-              200: '#e2e8f0',
-              300: '#cbd5e1',
-              400: '#94a3b8',
-              500: '#64748b',
-              600: '#475569',
-              700: '#334155',
-              800: '#1e293b',
-              900: '#0f172a',
-            },
-            accent: '#7c3aed',
-          },
-          animation: {
-            'fade-in': 'fadeIn 0.5s ease-in',
+          fontFamily: {
+            display: ['Sora', 'sans-serif'],
+            body: ['Plus Jakarta Sans', 'sans-serif'],
+            code: ['IBM Plex Mono', 'monospace']
           }
         }
       }
     }
   </script>
 
+  <link rel="stylesheet" href="/static/css/style.css" />
+
   <style>
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-        transform: translateY(10px);
-      }
-
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    .gradient-text {
-      background: linear-gradient(90deg, #0891b2, #2563eb);
-      -webkit-background-clip: text;
-      background-clip: text;
-      color: transparent;
-    }
-
-    .timeline-item:not(:last-child)::after {
-      content: '';
-      position: absolute;
-      left: 24px;
-      top: 44px;
-      bottom: -32px;
-      width: 2px;
-      background: #e2e8f0;
-      z-index: 1;
-    }
-
-    .skill-pill {
-      transition: all 0.3s ease;
-    }
-
-    .skill-pill:hover {
-      transform: translateY(-2px);
-    }
-
-    .project-card {
-      transition: all 0.3s ease;
-      background: linear-gradient(to bottom right, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.95));
-    }
-
-    .project-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
-    }
-
-    body {
-      background-color: #f8fafc;
-      background-image:
-        radial-gradient(at 10% 20%, rgba(8, 145, 178, 0.07) 0px, transparent 50%),
-        radial-gradient(at 90% 80%, rgba(37, 99, 235, 0.06) 0px, transparent 50%);
-    }
-
-    .glass-panel {
-      background: rgba(255, 255, 255, 0.85);
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
-      border: 1px solid rgba(255, 255, 255, 0.18);
+    /* Print / Save-as-PDF: flatten the dark theme to a clean white CV */
+    @media print {
+      nav, footer, .no-print, .glow { display: none !important; }
+      body { background: #fff !important; }
+      .glass, .glass-strong { background: #fff !important; border-color: #e2e8f0 !important; backdrop-filter: none !important; box-shadow: none !important; }
+      main { max-width: 100% !important; padding: 0 !important; }
+      * { color: #0f172a !important; }
+      .gradient-text { -webkit-text-fill-color: #0369a1 !important; color: #0369a1 !important; }
+      a { color: #0369a1 !important; text-decoration: none !important; }
+      section, .timeline-item { break-inside: avoid; }
     }
   </style>
 </head>
 
-<body class="min-h-screen">
+<body class="min-h-screen font-body">
   {% include "partials/navbar.html" %}
 
-  <main class="max-w-6xl mx-auto px-4 py-12">
+  <main class="relative max-w-6xl mx-auto px-4 py-12">
+    <div class="glow -left-20 top-10 h-64 w-64 bg-cyan-500/20"></div>
+    <div class="glow right-0 top-40 h-72 w-72 bg-orange-500/15"></div>
+
     <!-- Header -->
-    <div class="glass-panel rounded-2xl shadow-xl overflow-hidden mb-12 animate__animated animate__fade-in">
+    <div class="glass relative rounded-2xl shadow-xl overflow-hidden mb-12">
       <div class="p-8 md:p-12">
-        <div class="flex flex-col md:flex-row items-center">
+        <div class="flex flex-col md:flex-row items-center gap-8">
           <div class="md:w-2/3">
-            <h1 class="text-4xl md:text-5xl font-bold mb-2 font-heading text-slate-800">Hocine ABED</h1>
-            <h2 class="text-2xl md:text-3xl font-medium text-primary-600 mb-4">Web Scraping & Backend Development Expert
-            </h2>
-            <p class="text-lg text-slate-600 max-w-2xl">
-              Specialist in data extraction, high-performance API design, and cloud infrastructure management for
-              large-scale data processing.
+            <h1 class="text-4xl md:text-5xl font-extrabold mb-2 font-display text-white">Hocine ABED</h1>
+            <h2 class="text-xl md:text-2xl font-semibold gradient-text mb-4">Senior Web Scraping &amp; Anti-Bot Engineer</h2>
+            <p class="text-lg text-slate-300 max-w-2xl">
+              5+ years building high-volume crawlers (5–10M+ req/day) that bypass Cloudflare, DataDome, Akamai,
+              PerimeterX &amp; Imperva on Kubernetes. Expert in Playwright/Puppeteer (Python/Node/TS), fingerprint
+              spoofing, CAPTCHA solving and JS reverse engineering — delivering FastAPI BI endpoints (P95 &lt; 200 ms).
             </p>
             <div class="mt-6 flex flex-wrap gap-3">
-              <span class="px-3 py-1 bg-primary-100 text-primary-800 text-sm rounded-full">Python Expert</span>
-              <span class="px-3 py-1 bg-primary-100 text-primary-800 text-sm rounded-full">Web Scraping</span>
-              <span class="px-3 py-1 bg-primary-100 text-primary-800 text-sm rounded-full">Cloud Architecture</span>
+              <span class="px-3 py-1 border border-cyan-400/30 bg-cyan-400/10 text-cyan-200 text-sm rounded-full">Anti-Bot Bypass</span>
+              <span class="px-3 py-1 border border-cyan-400/30 bg-cyan-400/10 text-cyan-200 text-sm rounded-full">Reverse Engineering</span>
+              <span class="px-3 py-1 border border-cyan-400/30 bg-cyan-400/10 text-cyan-200 text-sm rounded-full">Python Expert</span>
+              <span class="px-3 py-1 border border-cyan-400/30 bg-cyan-400/10 text-cyan-200 text-sm rounded-full">Kubernetes</span>
             </div>
+            <button type="button" onclick="window.print()" class="no-print mt-6 inline-flex items-center rounded-xl bg-gradient-to-r from-cyan-400 to-blue-600 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:brightness-110">
+              <i class="fas fa-file-arrow-down mr-2"></i> Télécharger en PDF
+            </button>
           </div>
-          <div class="mt-8 md:mt-0 md:w-1/3 flex justify-center">
-            <div
-              class="w-40 h-40 rounded-full bg-gradient-to-br from-primary-400 to-accent shadow-lg flex items-center justify-center overflow-hidden">
+          <div class="md:w-1/3 flex justify-center">
+            <div class="w-40 h-40 rounded-full bg-gradient-to-br from-cyan-400 to-blue-600 p-[3px] shadow-lg shadow-cyan-500/20">
               <img
-                src="https://media.licdn.com/dms/image/v2/D4E03AQF3y-mQnpF4AQ/profile-displayphoto-scale_200_200/B4EZniGEFOHgAc-/0/1760434868480?e=1772668800&v=beta&t=QFPCx9XBvms2LVCZ0Bq-HydIpX24qUGmfOslKKAk-DI"
-                alt="Profile picture of Hocine ABED">
+                src="https://media.licdn.com/dms/image/v2/D4E03AQHsoy8Ka5YIng/profile-displayphoto-shrink_200_200/B4EZWjkFfyGgAY-/0/1742205901350?e=2147483647&v=beta&t=gpD57rl_Im2DnjGSpE7SzdLxwTa3pDU6zmBXE9WYhmA"
+                alt="Profile picture of Hocine ABED"
+                class="h-full w-full rounded-full object-cover">
             </div>
           </div>
         </div>
@@ -157,159 +88,151 @@
       <!-- Left Column -->
       <div class="lg:w-2/3">
         <!-- Experience -->
-        <section class="glass-panel rounded-2xl shadow-md p-8 mb-8 animate__animated animate__fade-in">
-          <h2 class="text-3xl font-bold mb-6 font-heading flex items-center">
+        <section class="glass rounded-2xl shadow-md p-8 mb-8">
+          <h2 class="text-2xl md:text-3xl font-bold mb-6 font-display flex items-center text-white">
             <span class="gradient-text">Professional Experience</span>
-            <span class="ml-auto text-sm font-normal text-slate-500">7+ years of experience</span>
+            <span class="ml-auto text-sm font-normal text-slate-400">5+ years</span>
           </h2>
 
           <div class="space-y-10">
-            <!-- Saper Vedere -->
+            <!-- SaperVedere -->
             <div class="timeline-item relative pl-14">
-              <div
-                class="absolute left-0 top-0 w-12 h-12 rounded-full bg-gradient-to-br from-primary-400 to-accent text-white flex items-center justify-center shadow-md z-10">
+              <div class="absolute left-0 top-0 w-12 h-12 rounded-full bg-gradient-to-br from-cyan-400 to-blue-600 text-slate-950 flex items-center justify-center shadow-md z-10">
                 <i class="fas fa-briefcase text-lg"></i>
               </div>
               <div class="ml-4">
                 <div class="flex flex-col md:flex-row md:justify-between">
-                  <h3 class="text-xl font-bold text-slate-800">Backend Developer</h3>
-                  <span class="text-primary-600 font-medium">July 2024 - Present</span>
+                  <h3 class="text-xl font-bold text-white">Senior Back-End Engineer (Scraping)</h3>
+                  <span class="text-cyan-300 font-medium">Jul 2024 - Present</span>
                 </div>
-                <div class="flex items-center text-slate-600 mb-4">
+                <div class="flex items-center text-slate-400 mb-4">
                   <i class="fas fa-building mr-2 text-sm opacity-70"></i>
-                  <span>Saper Vedere · Remote (Brussels Area)</span>
+                  <span>SaperVedere · Remote</span>
                 </div>
 
-                <div class="bg-primary-50/50 border-l-4 border-primary-500 p-5 rounded-r-lg mb-4">
-                  <ul class="list-disc list-inside space-y-2.5 text-slate-700">
-                    <li>Developed web scraping solutions for social media platforms (Facebook, Twitter, Instagram,
-                      TikTok) and various websites</li>
-                    <li>Managed proxy services to optimize scraping performance and ensure reliable data collection</li>
-                    <li>Designed and managed cloud infrastructure using Kubernetes, Docker, K9s, and cron jobs</li>
-                    <li>Built and deployed high-performance APIs using FastAPI</li>
-                    <li>Utilized Elasticsearch and MongoDB for advanced data indexing and storage</li>
-                    <li>Proficient in reverse engineering using tools like <strong>Proxyman</strong> and <strong>Charles Proxy</strong> to analyze and debug network traffic, optimize API interactions, and ensure robust data collection from various sources
-                    </li>
+                <div class="bg-white/5 border-l-4 border-cyan-400/60 p-5 rounded-r-lg mb-4">
+                  <ul class="list-disc list-inside space-y-2.5 text-slate-300">
+                    <li>Built near-real-time social-media collectors (Meta / TikTok / Instagram) processing millions of interactions daily (&lt; 5 min freshness)</li>
+                    <li>Reverse-engineered private APIs/endpoints (HTTP / TLS / WebSocket) and de-obfuscated JavaScript</li>
+                    <li>Designed anti-bot bypass (Cloudflare / DataDome / Akamai / PerimeterX / Imperva) with stealth fingerprinting &amp; CAPTCHA handling → <strong class="text-white">&gt;98% success rate</strong></li>
+                    <li>Owned the Kubernetes platform: orchestration, HPA, observability, cost-optimized proxy routing (<strong class="text-white">−35% proxy cost</strong>)</li>
+                    <li>Developed FastAPI BI services (P95 &lt; 200 ms, 99.9% SLO) + an LLM/RAG PoC for structured extraction (<strong class="text-white">+40% accuracy</strong>)</li>
                   </ul>
                 </div>
 
                 <div class="flex flex-wrap gap-2 mt-5">
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Python</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">FastAPI</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Kubernetes</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Docker</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Elasticsearch</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">MongoDB</span>
+                  {% for t in ["Python", "Playwright", "Reverse Engineering", "Kubernetes", "FastAPI", "MongoDB", "LLM/RAG"] %}
+                  <span class="px-3 py-1.5 border border-white/10 bg-white/5 text-slate-300 text-xs font-medium rounded-full">{{ t }}</span>
+                  {% endfor %}
                 </div>
               </div>
             </div>
 
-            <!-- PAARLY -->
+            <!-- Paarly Senior -->
             <div class="timeline-item relative pl-14">
-              <div
-                class="absolute left-0 top-0 w-12 h-12 rounded-full bg-gradient-to-br from-primary-400 to-accent text-white flex items-center justify-center shadow-md z-10">
+              <div class="absolute left-0 top-0 w-12 h-12 rounded-full bg-gradient-to-br from-cyan-400 to-blue-600 text-slate-950 flex items-center justify-center shadow-md z-10">
                 <i class="fas fa-briefcase text-lg"></i>
               </div>
               <div class="ml-4">
                 <div class="flex flex-col md:flex-row md:justify-between">
-                  <h3 class="text-xl font-bold text-slate-800">Lead Technical Developer</h3>
-                  <span class="text-primary-600 font-medium">Sept 2021 - Aug 2024</span>
+                  <h3 class="text-xl font-bold text-white">Senior Backend Developer — Web Scraping</h3>
+                  <span class="text-cyan-300 font-medium">Sep 2021 - Jun 2024</span>
                 </div>
-                <div class="flex items-center text-slate-600 mb-4">
+                <div class="flex items-center text-slate-400 mb-4">
                   <i class="fas fa-building mr-2 text-sm opacity-70"></i>
-                  <span>PAARLY · Hybrid (Toulouse, France)</span>
+                  <span>Paarly · Toulouse, France</span>
                 </div>
 
-                <div class="bg-primary-50/50 border-l-4 border-primary-500 p-5 rounded-r-lg mb-4">
-                  <ul class="list-disc list-inside space-y-2.5 text-slate-700">
-                    <li>Designed and implemented ETL pipelines using Scrapy, Puppeteer, and Selenium</li>
-                    <li>Integrated cloud solutions with Azure and AWS S3</li>
-                    <li>Created data visualizations with Power BI</li>
-                    <li>Managed proxies (brightdata) for performance optimization</li>
-                    <li>Prepared technical reports and project documentation</li>
-                    <li>Participated in client meetings and onboarded new team members</li>
+                <div class="bg-white/5 border-l-4 border-cyan-400/60 p-5 rounded-r-lg mb-4">
+                  <ul class="list-disc list-inside space-y-2.5 text-slate-300">
+                    <li>Architected price-intelligence pipelines scraping <strong class="text-white">100+ e-commerce sites</strong> (5M+ daily records, &lt;1% loss)</li>
+                    <li>Led a 5-engineer team: hiring, mentoring, planning, stakeholder alignment (95% on-time delivery)</li>
+                    <li>Built resilient crawlers (Playwright / Puppeteer / Scrapy) with retries, backoff and idempotency</li>
+                    <li>Implemented anti-blocking: residential proxies, custom fingerprints, TLS/JA3 spoofing, CAPTCHA solvers → <strong class="text-white">&gt;95% uptime</strong></li>
+                    <li>Delivered low-latency FastAPI endpoints (P95 &lt; 200 ms) feeding BI tools (Metabase / Power BI)</li>
                   </ul>
                 </div>
 
                 <div class="flex flex-wrap gap-2 mt-5">
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Scrapy</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Puppeteer</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Selenium</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Azure</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">AWS
-                    S3</span>
-                  <span
-                    class="skill-pill px-3 py-1.5 bg-primary-100 text-primary-800 text-xs font-medium rounded-full shadow-sm">Power
-                    BI</span>
+                  {% for t in ["Playwright", "Puppeteer", "Scrapy", "TLS/JA3", "Residential Proxies", "FastAPI", "Azure"] %}
+                  <span class="px-3 py-1.5 border border-white/10 bg-white/5 text-slate-300 text-xs font-medium rounded-full">{{ t }}</span>
+                  {% endfor %}
                 </div>
+              </div>
+            </div>
+
+            <!-- Paarly Intern -->
+            <div class="timeline-item relative pl-14">
+              <div class="absolute left-0 top-0 w-12 h-12 rounded-full bg-white/5 text-cyan-300 flex items-center justify-center shadow-md z-10">
+                <i class="fas fa-seedling text-lg"></i>
+              </div>
+              <div class="ml-4">
+                <div class="flex flex-col md:flex-row md:justify-between">
+                  <h3 class="text-lg font-bold text-white">Software Engineering Intern</h3>
+                  <span class="text-cyan-300 font-medium">Feb 2021 - Aug 2021</span>
+                </div>
+                <div class="flex items-center text-slate-400 mb-3">
+                  <i class="fas fa-building mr-2 text-sm opacity-70"></i>
+                  <span>Paarly · Toulouse, France</span>
+                </div>
+                <ul class="list-disc list-inside space-y-2 text-slate-300 text-sm">
+                  <li>Improved scraping reliability, monitoring &amp; alerting (−60% false positives)</li>
+                  <li>Supported Azure CI/CD and deployments</li>
+                </ul>
+              </div>
+            </div>
+
+            <!-- CDTA Intern -->
+            <div class="timeline-item relative pl-14">
+              <div class="absolute left-0 top-0 w-12 h-12 rounded-full bg-white/5 text-cyan-300 flex items-center justify-center shadow-md z-10">
+                <i class="fas fa-seedling text-lg"></i>
+              </div>
+              <div class="ml-4">
+                <div class="flex flex-col md:flex-row md:justify-between">
+                  <h3 class="text-lg font-bold text-white">Software Engineering Intern</h3>
+                  <span class="text-cyan-300 font-medium">Jan 2019 - Jul 2019</span>
+                </div>
+                <div class="flex items-center text-slate-400 mb-3">
+                  <i class="fas fa-building mr-2 text-sm opacity-70"></i>
+                  <span>CDTA · Algiers, Algeria</span>
+                </div>
+                <ul class="list-disc list-inside space-y-2 text-slate-300 text-sm">
+                  <li>Developed CNN object-detection models (TensorFlow / Keras) for autonomous driving</li>
+                </ul>
               </div>
             </div>
           </div>
         </section>
 
         <!-- Projects Showcase -->
-        <section class="glass-panel rounded-2xl shadow-md p-8 mb-8 animate__animated animate__fade-in">
-          <h2 class="text-3xl font-bold mb-6 font-heading">
+        <section class="glass rounded-2xl shadow-md p-8 mb-8">
+          <h2 class="text-2xl md:text-3xl font-bold mb-6 font-display">
             <span class="gradient-text">Notable Projects</span>
           </h2>
 
           <div class="grid md:grid-cols-2 gap-6">
-            <div class="project-card border border-slate-200 rounded-xl p-6">
-              <div class="flex items-center mb-4">
-                <div
-                  class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center text-indigo-600 mr-4 shadow-sm">
-                  <i class="fas fa-cloud text-xl"></i>
+            {% set cv_projects = [
+              {"title": "RAG Job Chatbot", "desc": "Semantic search over job posts using embeddings.", "icon": "fas fa-robot", "color": "violet", "tag": "Private", "url": null},
+              {"title": "Facebook Collector", "desc": "Posts & profiles → MongoDB / CSV via reverse-engineered endpoints.", "icon": "fab fa-facebook-f", "color": "blue", "tag": "GitHub", "url": "https://github.com/housine35/facebook-scraper"},
+              {"title": "TikTok Scraper API", "desc": "FastAPI + reverse engineering + Playwright.", "icon": "fab fa-tiktok", "color": "amber", "tag": "GitHub", "url": "https://github.com/housine35/tiktok-scraper"},
+              {"title": "LinkedIn Job Scraper", "desc": "Filtered postings with export, refreshed every 30 min.", "icon": "fab fa-linkedin-in", "color": "cyan", "tag": "GitHub", "url": "https://github.com/housine35/linkedin-job-scraper"}
+            ] %}
+            {% for p in cv_projects %}
+            <div class="card-hover rounded-xl border border-white/10 bg-white/5 p-6">
+              <div class="flex items-center justify-between mb-3">
+                <div class="w-11 h-11 bg-{{ p.color }}-400/15 rounded-lg flex items-center justify-center text-{{ p.color }}-300">
+                  <i class="{{ p.icon }} text-lg"></i>
                 </div>
-                <h3 class="text-lg font-bold text-slate-800">Social Media Data Extraction</h3>
+                {% if p.url %}
+                <a href="{{ p.url }}" target="_blank" rel="noopener noreferrer" class="text-xs font-medium text-{{ p.color }}-300 hover:text-{{ p.color }}-200"><i class="fab fa-github mr-1"></i>{{ p.tag }}</a>
+                {% else %}
+                <span class="text-xs font-medium text-slate-500"><i class="fas fa-lock mr-1"></i>{{ p.tag }}</span>
+                {% endif %}
               </div>
-              <div class="flex items-center mb-4">
-                <p class="text-slate-600 mr-3">App to extract data from:</p>
-                <div class="flex space-x-2">
-                  <img src="https://upload.wikimedia.org/wikipedia/commons/5/58/Instagram-Icon.png" alt="Instagram"
-                    class="w-5 h-5 object-contain">
-                  <img src="https://upload.wikimedia.org/wikipedia/commons/3/34/Ionicons_logo-tiktok.svg" alt="TikTok"
-                    class="w-5 h-5 object-contain">
-                  <img src="https://upload.wikimedia.org/wikipedia/commons/5/51/Facebook_f_logo_%282019%29.svg"
-                    alt="Facebook" class="w-5 h-5 object-contain">
-                </div>
-              </div>
-              <div class="flex flex-wrap gap-2">
-                <span class="px-2.5 py-1 bg-indigo-50 text-indigo-700 text-xs rounded-full shadow-sm">Python</span>
-                <span class="px-2.5 py-1 bg-indigo-50 text-indigo-700 text-xs rounded-full shadow-sm">FastAPI</span>
-                <span class="px-2.5 py-1 bg-indigo-50 text-indigo-700 text-xs rounded-full shadow-sm">playwright</span>
-                <span class="px-2.5 py-1 bg-indigo-50 text-indigo-700 text-xs rounded-full shadow-sm">K8s</span>
-                <span class="px-2.5 py-1 bg-indigo-50 text-indigo-700 text-xs rounded-full shadow-sm">Docker</span>
-                <span class="px-2.5 py-1 bg-indigo-50 text-indigo-700 text-xs rounded-full shadow-sm">AWS</span>
-              </div>
+              <h3 class="text-base font-bold text-white">{{ p.title }}</h3>
+              <p class="mt-1 text-sm text-slate-400">{{ p.desc }}</p>
             </div>
-
-            <div class="project-card border border-slate-200 rounded-xl p-6">
-              <div class="flex items-center mb-4">
-                <div
-                  class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center text-green-600 mr-4 shadow-sm">
-                  <i class="fas fa-database text-xl"></i>
-                </div>
-                <h3 class="text-lg font-bold text-slate-800">Jobs Plateforme scraper and ETL Pipeline</h3>
-              </div>
-              <p class="text-slate-600 mb-4">Complete solution for extracting, transforming and loading data from major
-                jobs platforms.</p>
-              <div class="flex flex-wrap gap-2">
-                <span class="px-2.5 py-1 bg-green-50 text-green-700 text-xs rounded-full shadow-sm">Python</span>
-                <span class="px-2.5 py-1 bg-green-50 text-green-700 text-xs rounded-full shadow-sm">FastAPI</span>
-                <span class="px-2.5 py-1 bg-green-50 text-green-700 text-xs rounded-full shadow-sm">Elasticsearch</span>
-              </div>
-            </div>
+            {% endfor %}
           </div>
         </section>
       </div>
@@ -317,166 +240,171 @@
       <!-- Right Column -->
       <div class="lg:w-1/3">
         <!-- Contact -->
-        <section class="glass-panel rounded-2xl shadow-md p-8 mb-8 animate__animated animate__fade-in">
-          <h2 class="text-2xl font-bold mb-6 font-heading">
+        <section class="glass rounded-2xl shadow-md p-8 mb-8">
+          <h2 class="text-2xl font-bold mb-6 font-display">
             <span class="gradient-text">Contact</span>
           </h2>
 
-          <div class="space-y-5">
-            <div class="flex items-center">
-              <div
-                class="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center text-primary-600 mr-4 shadow-sm">
+          <div class="space-y-5 text-sm">
+            <a href="mailto:abed.hocine@hotmail.com" class="flex items-center group">
+              <div class="w-10 h-10 bg-cyan-400/15 rounded-full flex items-center justify-center text-cyan-300 mr-4">
                 <i class="fas fa-envelope"></i>
               </div>
-              <a href="mailto:abed.hocine@hotmail.com"
-                class="hover:text-primary-600 transition text-slate-700">abed.hocine@hotmail.com</a>
-            </div>
+              <span class="text-slate-300 group-hover:text-cyan-300 transition">abed.hocine@hotmail.com</span>
+            </a>
 
-            <div class="flex items-center">
-              <div
-                class="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center text-primary-600 mr-4 shadow-sm">
+            <a href="tel:+33662404764" class="flex items-center group">
+              <div class="w-10 h-10 bg-cyan-400/15 rounded-full flex items-center justify-center text-cyan-300 mr-4">
                 <i class="fas fa-phone"></i>
               </div>
-              <a href="tel:+33612345678" class="hover:text-primary-600 transition text-slate-700">+33 6 12 34 56 78</a>
-            </div>
+              <span class="text-slate-300 group-hover:text-cyan-300 transition">+33 6 62 40 47 64</span>
+            </a>
 
-            <div class="flex items-center">
-              <div
-                class="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center text-primary-600 mr-4 shadow-sm">
+            <a href="https://www.linkedin.com/in/hocine-abed-33979a27/" target="_blank" rel="noopener noreferrer" class="flex items-center group">
+              <div class="w-10 h-10 bg-cyan-400/15 rounded-full flex items-center justify-center text-cyan-300 mr-4">
                 <i class="fab fa-linkedin-in"></i>
               </div>
-              <a href="#" target="_blank"
-                class="hover:text-primary-600 transition text-slate-700">linkedin.com/in/hocine-abed</a>
-            </div>
+              <span class="text-slate-300 group-hover:text-cyan-300 transition">linkedin.com/in/hocine-abed</span>
+            </a>
 
-            <div class="flex items-center">
-              <div
-                class="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center text-primary-600 mr-4 shadow-sm">
+            <a href="https://github.com/housine35" target="_blank" rel="noopener noreferrer" class="flex items-center group">
+              <div class="w-10 h-10 bg-cyan-400/15 rounded-full flex items-center justify-center text-cyan-300 mr-4">
                 <i class="fab fa-github"></i>
               </div>
-              <a href="#" target="_blank"
-                class="hover:text-primary-600 transition text-slate-700">github.com/hocine-abed</a>
-            </div>
+              <span class="text-slate-300 group-hover:text-cyan-300 transition">github.com/housine35</span>
+            </a>
           </div>
         </section>
 
         <!-- Skills -->
-        <section class="glass-panel rounded-2xl shadow-md p-8 mb-8 animate__animated animate__fade-in">
-          <h2 class="text-2xl font-bold mb-6 font-heading">
+        <section class="glass rounded-2xl shadow-md p-8 mb-8">
+          <h2 class="text-2xl font-bold mb-6 font-display">
             <span class="gradient-text">Technical Skills</span>
           </h2>
 
           <div class="space-y-6">
             <div>
-              <h3 class="text-lg font-semibold mb-3 flex items-center text-slate-700">
-                <i class="fas fa-code mr-2 text-primary-500"></i>
-                Languages
+              <h3 class="text-base font-semibold mb-3 flex items-center text-slate-200">
+                <i class="fas fa-shield-halved mr-2 text-cyan-300"></i> Anti-Bot
               </h3>
               <div class="flex flex-wrap gap-2">
-                <span
-                  class="skill-pill px-3 py-1.5 bg-green-100 text-green-800 rounded-full text-xs shadow-sm">Python</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-green-100 text-green-800 rounded-full text-xs shadow-sm">JavaScript</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-green-100 text-green-800 rounded-full text-xs shadow-sm">SQL</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-green-100 text-green-800 rounded-full text-xs shadow-sm">Shell</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-green-100 text-green-800 rounded-full text-xs shadow-sm">PHP</span>
+                {% for t in ["Cloudflare", "DataDome", "Akamai", "PerimeterX", "Imperva", "CAPTCHA solvers", "Bright Data", "Oxylabs"] %}
+                <span class="px-3 py-1.5 border border-cyan-400/25 bg-cyan-400/10 text-cyan-200 rounded-full text-xs">{{ t }}</span>
+                {% endfor %}
               </div>
             </div>
 
             <div>
-              <h3 class="text-lg font-semibold mb-3 flex items-center text-slate-700">
-                <i class="fas fa-cogs mr-2 text-primary-500"></i>
-                Frameworks & Tools
+              <h3 class="text-base font-semibold mb-3 flex items-center text-slate-200">
+                <i class="fas fa-spider mr-2 text-cyan-300"></i> Scraping &amp; Reverse Eng.
               </h3>
               <div class="flex flex-wrap gap-2">
-                <span
-                  class="skill-pill px-3 py-1.5 bg-purple-100 text-purple-800 rounded-full text-xs shadow-sm">FastAPI</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-purple-100 text-purple-800 rounded-full text-xs shadow-sm">Flask</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-purple-100 text-purple-800 rounded-full text-xs shadow-sm">Scrapy</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-purple-100 text-purple-800 rounded-full text-xs shadow-sm">Selenium</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-purple-100 text-purple-800 rounded-full text-xs shadow-sm">Puppeteer</span>
+                {% for t in ["Playwright", "Puppeteer", "Scrapy", "Selenium", "JS reverse-eng", "Fingerprint spoofing", "TLS/JA3"] %}
+                <span class="px-3 py-1.5 border border-white/10 bg-white/5 text-slate-300 rounded-full text-xs">{{ t }}</span>
+                {% endfor %}
               </div>
             </div>
 
             <div>
-              <h3 class="text-lg font-semibold mb-3 flex items-center text-slate-700">
-                <i class="fas fa-database mr-2 text-primary-500"></i>
-                Databases
+              <h3 class="text-base font-semibold mb-3 flex items-center text-slate-200">
+                <i class="fas fa-code mr-2 text-cyan-300"></i> Languages
               </h3>
               <div class="flex flex-wrap gap-2">
-                <span
-                  class="skill-pill px-3 py-1.5 bg-amber-100 text-amber-800 rounded-full text-xs shadow-sm">MongoDB</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-amber-100 text-amber-800 rounded-full text-xs shadow-sm">Elasticsearch</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-amber-100 text-amber-800 rounded-full text-xs shadow-sm">PostgreSQL</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-amber-100 text-amber-800 rounded-full text-xs shadow-sm">Redis</span>
+                {% for t in ["Python", "JavaScript", "TypeScript", "Node.js"] %}
+                <span class="px-3 py-1.5 border border-white/10 bg-white/5 text-slate-300 rounded-full text-xs">{{ t }}</span>
+                {% endfor %}
               </div>
             </div>
 
             <div>
-              <h3 class="text-lg font-semibold mb-3 flex items-center text-slate-700">
-                <i class="fas fa-cloud mr-2 text-primary-500"></i>
-                Cloud & DevOps
+              <h3 class="text-base font-semibold mb-3 flex items-center text-slate-200">
+                <i class="fas fa-brain mr-2 text-cyan-300"></i> AI / LLM
               </h3>
               <div class="flex flex-wrap gap-2">
-                <span
-                  class="skill-pill px-3 py-1.5 bg-blue-100 text-blue-800 rounded-full text-xs shadow-sm">Kubernetes</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-blue-100 text-blue-800 rounded-full text-xs shadow-sm">Docker</span>
-                <span class="skill-pill px-3 py-1.5 bg-blue-100 text-blue-800 rounded-full text-xs shadow-sm">AWS</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-blue-100 text-blue-800 rounded-full text-xs shadow-sm">Azure</span>
-                <span
-                  class="skill-pill px-3 py-1.5 bg-blue-100 text-blue-800 rounded-full text-xs shadow-sm">CI/CD</span>
+                {% for t in ["RAG", "Embeddings", "Prompt engineering", "Function calling", "Vector stores"] %}
+                <span class="px-3 py-1.5 border border-white/10 bg-white/5 text-slate-300 rounded-full text-xs">{{ t }}</span>
+                {% endfor %}
+              </div>
+            </div>
+
+            <div>
+              <h3 class="text-base font-semibold mb-3 flex items-center text-slate-200">
+                <i class="fas fa-server mr-2 text-cyan-300"></i> Infra
+              </h3>
+              <div class="flex flex-wrap gap-2">
+                {% for t in ["Docker", "Kubernetes", "Airflow", "Celery", "FastAPI", "WebSockets"] %}
+                <span class="px-3 py-1.5 border border-white/10 bg-white/5 text-slate-300 rounded-full text-xs">{{ t }}</span>
+                {% endfor %}
+              </div>
+            </div>
+
+            <div>
+              <h3 class="text-base font-semibold mb-3 flex items-center text-slate-200">
+                <i class="fas fa-database mr-2 text-cyan-300"></i> Data &amp; Cloud
+              </h3>
+              <div class="flex flex-wrap gap-2">
+                {% for t in ["MongoDB", "Elasticsearch", "PostgreSQL", "Azure", "GCP", "Prometheus/Grafana"] %}
+                <span class="px-3 py-1.5 border border-white/10 bg-white/5 text-slate-300 rounded-full text-xs">{{ t }}</span>
+                {% endfor %}
               </div>
             </div>
           </div>
         </section>
 
         <!-- Education -->
-        <section class="glass-panel rounded-2xl shadow-md p-8 animate__animated animate__fade-in">
-          <h2 class="text-2xl font-bold mb-6 font-heading">
+        <section class="glass rounded-2xl shadow-md p-8 mb-8">
+          <h2 class="text-2xl font-bold mb-6 font-display">
             <span class="gradient-text">Education</span>
           </h2>
 
           <div class="space-y-5">
             <div class="flex">
               <div class="mr-4">
-                <div
-                  class="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center text-primary-600 shadow-sm">
+                <div class="w-10 h-10 bg-cyan-400/15 rounded-full flex items-center justify-center text-cyan-300">
                   <i class="fas fa-graduation-cap"></i>
                 </div>
               </div>
               <div>
-                <h3 class="font-bold text-slate-800">Master's in Computer Science</h3>
-                <p class="text-slate-600">Haute Asace University</p>
-                <p class="text-sm text-slate-500">2018 - 2020</p>
+                <h3 class="font-bold text-white">MSc Computer Science (Data Eng.)</h3>
+                <p class="text-slate-400">Université de Haute-Alsace, France</p>
+                <p class="text-sm text-slate-500">2021</p>
               </div>
             </div>
 
             <div class="flex">
               <div class="mr-4">
-                <div
-                  class="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center text-primary-600 shadow-sm">
-                  <i class="fas fa-certificate"></i>
+                <div class="w-10 h-10 bg-cyan-400/15 rounded-full flex items-center justify-center text-cyan-300">
+                  <i class="fas fa-graduation-cap"></i>
                 </div>
               </div>
               <div>
-                <h3 class="font-bold text-slate-800">Kubernetes Certification</h3>
-                <p class="text-slate-600">CNCF</p>
-                <p class="text-sm text-slate-500">2023</p>
+                <h3 class="font-bold text-white">MSc Computer Vision</h3>
+                <p class="text-slate-400">Univ. M'hamed Bougara, Algeria</p>
+                <p class="text-sm text-slate-500">2019</p>
               </div>
             </div>
           </div>
+        </section>
+
+        <!-- Languages -->
+        <section class="glass rounded-2xl shadow-md p-8">
+          <h2 class="text-2xl font-bold mb-6 font-display">
+            <span class="gradient-text">Languages</span>
+          </h2>
+          <ul class="space-y-3 text-sm">
+            <li class="flex items-center justify-between">
+              <span class="text-slate-300">English</span>
+              <span class="text-slate-500">Professional fluency</span>
+            </li>
+            <li class="flex items-center justify-between">
+              <span class="text-slate-300">French</span>
+              <span class="text-slate-500">Native</span>
+            </li>
+            <li class="flex items-center justify-between">
+              <span class="text-slate-300">Arabic</span>
+              <span class="text-slate-500">Native</span>
+            </li>
+          </ul>
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Dark theme across all pages via shared `static/css/style.css`
- Anti-bot / reverse-engineering positioning; hero terminal + **live Mongo job counter**
- LinkedIn page: keyword search, application tracking (localStorage), **IT-jobs-only** filter
- Project **case-study pages** (`/projects/<slug>`) + `sitemap.xml`, `robots.txt`, JSON-LD, OG tags
- Resume rebuilt from latest CV (Senior Web Scraping & Anti-Bot Engineer) + print-to-PDF
- Fixed broken CV data/links (phone, LinkedIn/GitHub, photo, university typo)
- Pinned `starlette==0.46.2` for FastAPI 0.115 compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)