### PR TITLE
Fix: trust proxy headers for https og:image/canonical on Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]


### PR DESCRIPTION
uvicorn `--proxy-headers --forwarded-allow-ips=*` so `request.url` reflects `X-Forwarded-Proto` (https) behind Railway's proxy. Fixes http:// Open Graph image and canonical URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)